### PR TITLE
Fix: Incorrect AbstractInputObjectType location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,7 +1081,7 @@ namespace Examples\Blog\Schema;
 
 use Youshido\GraphQL\Type\Config\InputTypeConfigInterface;
 use Youshido\GraphQL\Type\NonNullType;
-use Youshido\GraphQL\Type\Object\AbstractInputObjectType;
+use Youshido\GraphQL\Type\InputObject\AbstractInputObjectType;
 use Youshido\GraphQL\Type\Scalar\StringType;
 
 class PostInputType extends AbstractInputObjectType


### PR DESCRIPTION
Hey - This is to correct the example 

AbstractInputObjectType is on the InputObject folder.