### PR TITLE
Fixed typo in example

### DIFF
--- a/examples/03_relay_star_wars/Schema/FactionType.php
+++ b/examples/03_relay_star_wars/Schema/FactionType.php
@@ -9,7 +9,7 @@
 namespace Examples\StarWars;
 
 
-use Youshido\GraphQl\Relay\Connection\ArrayConnection;
+use Youshido\GraphQL\Relay\Connection\ArrayConnection;
 use Youshido\GraphQL\Relay\Connection\Connection;
 use Youshido\GraphQL\Relay\Field\GlobalIdField;
 use Youshido\GraphQL\Relay\NodeInterfaceType;


### PR DESCRIPTION
Changed `GraphQl` to `GraphQL`.

Typo prevented class ArrayConnection to be found.