### PR TITLE
validate query arguments while processing AST

### DIFF
--- a/Tests/DataProvider/TestObjectType.php
+++ b/Tests/DataProvider/TestObjectType.php
@@ -8,6 +8,7 @@
 
 namespace Youshido\Tests\DataProvider;
 
+use Youshido\GraphQL\Type\ListType\ListType;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 use Youshido\GraphQL\Type\Object\ObjectType;
 use Youshido\GraphQL\Type\Scalar\IntType;
@@ -29,6 +30,23 @@ class TestObjectType extends AbstractObjectType
                     'city'    => new StringType()
                 ],
             ]))
+            ->addField('location', [
+                 'type'    => new ObjectType(
+                     [
+                         'name'   => 'Location',
+                         'fields' => [
+                             'address'    => new StringType()
+                         ]
+                     ]
+                 ),
+                 'args'    => [
+                     'noop' => new IntType()
+                 ],
+                 'resolve' => function ($value, $args, $info) {
+                   return ['address' => '1234 Street'];
+                 }
+             ]
+            )
             ->addField(
                 'echo', [
                     'type'    => new StringType(),

--- a/Tests/DataProvider/TestObjectType.php
+++ b/Tests/DataProvider/TestObjectType.php
@@ -12,6 +12,7 @@ use Youshido\GraphQL\Type\Object\AbstractObjectType;
 use Youshido\GraphQL\Type\Object\ObjectType;
 use Youshido\GraphQL\Type\Scalar\IntType;
 use Youshido\GraphQL\Type\Scalar\StringType;
+use Youshido\GraphQL\Type\NonNullType;
 
 class TestObjectType extends AbstractObjectType
 {
@@ -27,7 +28,18 @@ class TestObjectType extends AbstractObjectType
                     'country' => new StringType(),
                     'city'    => new StringType()
                 ],
-            ]));
+            ]))
+            ->addField(
+                'echo', [
+                    'type'    => new StringType(),
+                    'args'    => [
+                        'value' => new NonNullType(new StringType())
+                    ],
+                    'resolve' => function ($value, $args, $info) {
+                        return $args['value'];
+                    }
+                ]
+            );
     }
 
     public function getInterfaces()

--- a/Tests/DataProvider/TestObjectType.php
+++ b/Tests/DataProvider/TestObjectType.php
@@ -8,7 +8,6 @@
 
 namespace Youshido\Tests\DataProvider;
 
-use Youshido\GraphQL\Type\ListType\ListType;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 use Youshido\GraphQL\Type\Object\ObjectType;
 use Youshido\GraphQL\Type\Scalar\IntType;

--- a/Tests/DataProvider/TestSchema.php
+++ b/Tests/DataProvider/TestSchema.php
@@ -12,6 +12,8 @@ namespace Youshido\Tests\DataProvider;
 use Youshido\GraphQL\Config\Schema\SchemaConfig;
 use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Schema\AbstractSchema;
+use Youshido\GraphQL\Type\NonNullType;
+use Youshido\GraphQL\Type\Scalar\StringType;
 
 class TestSchema extends AbstractSchema
 {

--- a/Tests/DataProvider/TestSchema.php
+++ b/Tests/DataProvider/TestSchema.php
@@ -13,6 +13,7 @@ use Youshido\GraphQL\Config\Schema\SchemaConfig;
 use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Schema\AbstractSchema;
 use Youshido\GraphQL\Type\NonNullType;
+use Youshido\GraphQL\Type\Scalar\IntType;
 use Youshido\GraphQL\Type\Scalar\StringType;
 
 class TestSchema extends AbstractSchema

--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -55,6 +55,23 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     }
 
+  public function testNestedVariables() {
+    $processor = new Processor(new TestSchema());
+    $no_args_query = '{ me { echo(value:"foo") } }';
+    $expected_data = ['data' => ['me' => ['echo' => 'foo']]];
+    $processor->processPayload($no_args_query, ['value' => 'foo']);
+    $this->assertEquals($expected_data, $processor->getResponseData());
+
+    $parameterized_query =
+        'query nestedQuery($value:String!){
+          me {
+            echo(value:$value)
+          }
+        }';
+    $processor->processPayload($parameterized_query, ['value' => 'foo']);
+    $this->assertEquals($expected_data, $processor->getResponseData());
+  }
+
     public function testListNullResponse()
     {
         $processor = new Processor(new Schema([

--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -57,19 +57,30 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
   public function testNestedVariables() {
     $processor = new Processor(new TestSchema());
-    $no_args_query = '{ me { echo(value:"foo") } }';
-    $expected_data = ['data' => ['me' => ['echo' => 'foo']]];
-    $processor->processPayload($no_args_query, ['value' => 'foo']);
-    $this->assertEquals($expected_data, $processor->getResponseData());
+    $noArgsQuery = '{ me { echo(value:"foo") } }';
+    $expectedData = ['data' => ['me' => ['echo' => 'foo']]];
+    $processor->processPayload($noArgsQuery, ['value' => 'foo']);
+    $this->assertEquals($expectedData, $processor->getResponseData());
 
-    $parameterized_query =
-        'query nestedQuery($value:String!){
+    $parameterizedFieldQuery =
+        'query nestedFieldQuery($value:String!){
           me {
             echo(value:$value)
           }
         }';
-    $processor->processPayload($parameterized_query, ['value' => 'foo']);
-    $this->assertEquals($expected_data, $processor->getResponseData());
+    $processor->processPayload($parameterizedFieldQuery, ['value' => 'foo']);
+    $this->assertEquals($expectedData, $processor->getResponseData());
+
+    $parameterizedQueryQuery =
+        'query nestedQueryQuery($value:Int){
+          me {
+            location(noop:$value) {
+              address
+            }
+          }
+        }';
+    $processor->processPayload($parameterizedQueryQuery, ['value' => 1]);
+    $this->assertArrayNotHasKey('errors', $processor->getResponseData());
   }
 
     public function testListNullResponse()

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -126,6 +126,10 @@ class Processor
      */
     protected function processQueryAST(Query $query, AbstractField $field, $contextValue = null)
     {
+        if (!$this->resolveValidator->validateArguments($field, $query, $this->executionContext->getRequest())) {
+            return null;
+        }
+
         $resolvedValue = $this->resolveFieldValue($field, $contextValue, $query);
 
         if (!$this->resolveValidator->isValidValueForField($field, $resolvedValue)) {

--- a/src/Introspection/FieldType.php
+++ b/src/Introspection/FieldType.php
@@ -25,7 +25,7 @@ class FieldType extends AbstractObjectType
             ->addField('type', [
                 'type'    => new QueryType(),
                 'resolve' => function (AbstractField $value) {
-                    return $value->getType()->getNamedType();
+                    return $value->getType();
                 }
             ])
             ->addField('args', [


### PR DESCRIPTION
fix for https://github.com/Youshido/GraphQL/issues/12.  Without this, nested queries that have both resolveFuncs and arguments complain:

```
{errors: {message: "Value is not set for variable \"value\""}}
```

I'm not sure this is the cleanest fix, I defer to the authors on that.