### PR TITLE
allow default typeservice to resolve public fields on objects

### DIFF
--- a/Tests/Library/Utilities/TypeUtilitiesTest.php
+++ b/Tests/Library/Utilities/TypeUtilitiesTest.php
@@ -14,6 +14,7 @@ use Youshido\GraphQL\Type\TypeMap;
 use Youshido\GraphQL\Type\TypeService;
 use Youshido\Tests\DataProvider\TestInterfaceType;
 use Youshido\Tests\DataProvider\TestObjectType;
+use Youshido\Tests\Library\Type\ObjectTypeTest;
 
 class TypeUtilitiesTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,5 +55,12 @@ class TypeUtilitiesTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(TypeService::isAbstractType(new TestInterfaceType()));
         $this->assertFalse(TypeService::isAbstractType(new StringType()));
         $this->assertFalse(TypeService::isAbstractType('invalid type'));
+    }
+
+    public function testGetPropertyValue() {
+        $arrayData = (new TestObjectType())->getData();
+
+        $this->assertEquals('John', TypeService::getPropertyValue($arrayData, 'name'));
+        $this->assertEquals('John', TypeService::getPropertyValue((object) $arrayData, 'name'));
     }
 }

--- a/src/Type/TypeService.php
+++ b/src/Type/TypeService.php
@@ -122,6 +122,9 @@ class TypeService
     public static function getPropertyValue($data, $path)
     {
         if (is_object($data)) {
+            if (isset($data->$path)) {
+                return $data->$path;
+            }
             $getter = $path;
             if (substr($path, 0, 2) != 'is') {
                 $getter = 'get' . self::classify($path);

--- a/src/Type/TypeService.php
+++ b/src/Type/TypeService.php
@@ -122,15 +122,12 @@ class TypeService
     public static function getPropertyValue($data, $path)
     {
         if (is_object($data)) {
-            if (isset($data->$path)) {
-                return $data->$path;
-            }
             $getter = $path;
             if (substr($path, 0, 2) != 'is') {
                 $getter = 'get' . self::classify($path);
             }
 
-            return is_callable([$data, $getter]) ? $data->$getter() : null;
+            return is_callable([$data, $getter]) ? $data->$getter() : (isset($data->$path) ? $data->$path : null);
         } elseif (is_array($data)) {
             return array_key_exists($path, $data) ? $data[$path] : null;
         }


### PR DESCRIPTION
Currently objects only support `$foo->getBar()` getters by default, this enables `$foo->bar` as well.  Provides symmetry with arrays which support `$foo['bar']`.