### PR TITLE
do not explicitly cast to array when iterating over resolvedValue as it does not play well with classes implementing \IteratorAggregate

### DIFF
--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -152,7 +152,7 @@ class Processor
 
         $value = [];
         if ($fieldType->getKind() == TypeMap::KIND_LIST) {
-            foreach ((array)$resolvedValue as $resolvedValueItem) {
+            foreach ($resolvedValue as $resolvedValueItem) {
                 $value[] = [];
                 $index   = count($value) - 1;
 


### PR DESCRIPTION
Per title.  

Let me know if you want a test to cover the use case here, it's a bit specific to my app.  The gist is that I have some classes like:

`class Foo implements \IteratorAggregate {...}`

and these are `isValidValue` for an `AbstractListType`, but the explicit array cast causes undesirable iteration behavior.