### PR TITLE
Make it possible to store a string as resolve function

### DIFF
--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -10,6 +10,7 @@ namespace Youshido\Tests\Schema;
 
 
 use Youshido\GraphQL\Execution\Processor;
+use Youshido\GraphQL\Execution\ResolveStringResolverInterface;
 use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Field\Field;
 use Youshido\GraphQL\Schema\Schema;
@@ -446,6 +447,30 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->processPayload('{ invalidUnion { ... on Object2 { name } } }');
         $this->assertEquals(['errors' => [['message' => 'Type Object3 not exist in types of Object2']]], $processor->getResponseData());
 
+    }
+
+    public function testSchemaWithResolveString()
+    {
+        $resolveFactory = $this->prophesize(ResolveStringResolverInterface::class);
+        $resolveFactory->resolve('service_name:get')
+            ->shouldBeCalled()
+            ->willReturn(function () {
+                return 'hello';
+            });
+
+        $processor = new Processor(new Schema([
+            'query' => new ObjectType([
+                'name' => 'RootQuery',
+                'fields' => [
+                    'string' => [
+                        'type' => new StringType(),
+                        'resolveString' => 'service_name:get',
+                    ]
+                ]
+            ])
+        ]), $resolveFactory->reveal());
+        $data = $processor->processPayload(' { string }')->getResponseData();
+        $this->assertEquals(['data' => ['string' => 'hello']], $data);
     }
 
 

--- a/src/Config/AbstractConfig.php
+++ b/src/Config/AbstractConfig.php
@@ -93,6 +93,14 @@ abstract class AbstractConfig
         return $this->get('resolve', null);
     }
 
+  /**
+   * @return string|null
+   */
+    public function getResolveString()
+    {
+        return $this->get('resolveString', null);
+    }
+
     protected function build()
     {
     }

--- a/src/Config/Field/FieldConfig.php
+++ b/src/Config/Field/FieldConfig.php
@@ -27,6 +27,7 @@ class FieldConfig extends AbstractConfig
             'args'              => ['type' => TypeService::TYPE_ARRAY],
             'description'       => ['type' => TypeService::TYPE_STRING],
             'resolve'           => ['type' => TypeService::TYPE_CALLABLE],
+            'resolveString'    => ['type' => TypeService::TYPE_STRING],
             'isDeprecated'      => ['type' => TypeService::TYPE_BOOLEAN],
             'deprecationReason' => ['type' => TypeService::TYPE_STRING],
         ];

--- a/src/Config/Object/ListTypeConfig.php
+++ b/src/Config/Object/ListTypeConfig.php
@@ -18,6 +18,7 @@ class ListTypeConfig extends ObjectTypeConfig
         return [
             'itemType' => ['type' => TypeService::TYPE_GRAPHQL_TYPE, 'final' => true],
             'resolve'  => ['type' => TypeService::TYPE_CALLABLE],
+            'resolveString'  => ['type' => TypeService::TYPE_STRING],
             'args'     => ['type' => TypeService::TYPE_ARRAY_OF_INPUT_FIELDS],
         ];
     }

--- a/src/Execution/ResolveStringResolverInterface.php
+++ b/src/Execution/ResolveStringResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Youshido\GraphQL\Execution;
+
+/**
+ * Provides a factory for resolvers.
+ *
+ * For some advanced usecases one might not actually want an anonymous function
+ * for the resolver, like for caching purposes. This function allows you to
+ * just provide the string and create the resolver on runtime.
+ */
+interface ResolveStringResolverInterface
+{
+    /**
+     * Returns the resolve function.
+     *
+     * @param string $resolveString
+     *   The passed in factory, maybe for example service_name:get.
+     *
+     * @return callable
+     */
+    public function resolve($resolveString);
+
+}

--- a/src/Validator/ConfigValidator/Rules/TypeValidationRule.php
+++ b/src/Validator/ConfigValidator/Rules/TypeValidationRule.php
@@ -195,6 +195,7 @@ class TypeValidationRule implements ValidationRuleInterface
             'args'              => ['type' => TypeService::TYPE_ARRAY],
             'description'       => ['type' => TypeService::TYPE_STRING],
             'resolve'           => ['type' => TypeService::TYPE_CALLABLE],
+            'resolveString'    => ['type' => TypeService::TYPE_STRING],
             'isDeprecated'      => ['type' => TypeService::TYPE_BOOLEAN],
             'deprecationReason' => ['type' => TypeService::TYPE_STRING],
         ];


### PR DESCRIPTION
Creating the entire graph of your data structure can be costly, so you want to be able to cache it.

Sadly using callables makes that not really possible at the moment.

Here is an approach which allows to store just strings internally but then resolve the resolvers (feel free to bikeshed ;)) on runtime using an additional class.

We as in Drupal could leverage this functionality

@fubhy Please also chime in, in case you have more comments