### PR TITLE
remove mongo dependency

### DIFF
--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -152,7 +152,7 @@ class Processor
 
         $value = [];
         if ($fieldType->getKind() == TypeMap::KIND_LIST) {
-            foreach ((array)$resolvedValue as $resolvedValueItem) {
+            foreach ($resolvedValue as $resolvedValueItem) {
                 $value[] = [];
                 $index   = count($value) - 1;
 

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -7,7 +7,6 @@
 
 namespace Youshido\GraphQL\Validator\ResolveValidator;
 
-use MongoDB\BSON\Serializable;
 use Youshido\GraphQL\Execution\Context\ExecutionContextInterface;
 use Youshido\GraphQL\Execution\Request;
 use Youshido\GraphQL\Field\AbstractField;
@@ -184,7 +183,6 @@ class ResolveValidator implements ResolveValidatorInterface
         return is_array($data) ||
                ($data instanceof \ArrayAccess &&
                 $data instanceof \Traversable &&
-                $data instanceof Serializable &&
                 $data instanceof \Countable);
     }
 


### PR DESCRIPTION
phpstorm autocompletion oopsie 😄 

If you can, please remove this check entirely; we have classes that implement `__sleep` instead of `\Serializable`, so this check doesn't work there.

In general determining if an object is serializable is a Hard problem since `[function() {}]` is not serializable, so I don't think this check is very useful.