### PR TITLE
Give resolver functions precedence over automatically resolving from …

### DIFF
--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -252,6 +252,19 @@ class Processor
         $resolved      = false;
         $resolverValue = null;
 
+        if ($resolveFunction = $field->getConfig()->getResolveFunction()) {
+            $resolveInfo = new ResolveInfo($field, [$fieldAst], $field->getType(), $this->executionContext);
+
+            if (!$this->resolveValidator->validateArguments($field, $fieldAst, $this->executionContext->getRequest())) {
+                throw new \Exception(sprintf('Not valid arguments for the field "%s"', $fieldAst->getName()));
+
+            } else {
+                $resolverValue = $resolveFunction($resolved ? $resolverValue : $contextValue, $fieldAst->getKeyValueArguments(), $resolveInfo);
+                $resolved      = true;
+            }
+
+        }
+
         if (is_array($contextValue) && array_key_exists($fieldAst->getName(), $contextValue)) {
             $resolverValue = $contextValue[$fieldAst->getName()];
             $resolved      = true;
@@ -262,18 +275,6 @@ class Processor
 
         if (!$resolved && $field->getType()->getNamedType()->getKind() == TypeMap::KIND_SCALAR) {
             $resolved = true;
-        }
-
-        if ($resolveFunction = $field->getConfig()->getResolveFunction()) {
-            $resolveInfo = new ResolveInfo($field, [$fieldAst], $field->getType(), $this->executionContext);
-
-            if (!$this->resolveValidator->validateArguments($field, $fieldAst, $this->executionContext->getRequest())) {
-                throw new \Exception(sprintf('Not valid arguments for the field "%s"', $fieldAst->getName()));
-
-            } else {
-                $resolverValue = $resolveFunction($resolved ? $resolverValue : $contextValue, $fieldAst->getKeyValueArguments(), $resolveInfo);
-            }
-
         }
 
         if (!$resolverValue && !$resolved) {


### PR DESCRIPTION
…object properties or array values.

Otherwise, custom resolver functions specified in the field declaration are skipped if the parent resolved value is an object/array.