### PR TITLE
Add introspection fields during schema initialization.

### DIFF
--- a/Tests/DataProvider/TestEmptySchema.php
+++ b/Tests/DataProvider/TestEmptySchema.php
@@ -14,11 +14,6 @@ use Youshido\GraphQL\Schema\AbstractSchema;
 
 class TestEmptySchema extends AbstractSchema
 {
-    public function build(SchemaConfig $config)
-    {
-    }
-
-
     public function getName()
     {
         return 'TestSchema';

--- a/Tests/DataProvider/TestSchema.php
+++ b/Tests/DataProvider/TestSchema.php
@@ -22,6 +22,8 @@ class TestSchema extends AbstractSchema
 
     public function build(SchemaConfig $config)
     {
+        parent::build($config);
+
         $config->getQuery()->addFields([
             'me'     => [
                 'type'    => new TestObjectType(),

--- a/Tests/Library/Validator/SchemaValidatorTest.php
+++ b/Tests/Library/Validator/SchemaValidatorTest.php
@@ -25,8 +25,15 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidSchema()
     {
+        $schema = new TestEmptySchema();
+
+        // Remove the introspection fields.
+        $schema->getQueryType()->getConfig()
+            ->removeField('__type')
+            ->removeField('__schema');
+
         $validator = new SchemaValidator();
-        $validator->validate(new TestEmptySchema());
+        $validator->validate($schema);
     }
 
     /**

--- a/Tests/Schema/IntrospectionTest.php
+++ b/Tests/Schema/IntrospectionTest.php
@@ -192,17 +192,17 @@ TEXT;
                         '__schema' => [
                             'types' => [
                                 ['name' => 'TestSchemaQuery', 'fields' => [['name' => 'latest']]],
-                                ['name' => 'Int', 'fields' => null],
-                                ['name' => 'LatestType', 'fields' => [['name' => 'id'], ['name' => 'name']]],
-                                ['name' => 'String', 'fields' => null],
                                 ['name' => '__Schema', 'fields' => [['name' => 'queryType'], ['name' => 'mutationType'], ['name' => 'subscriptionType'], ['name' => 'types'], ['name' => 'directives']]],
                                 ['name' => '__Type', 'fields' => [['name' => 'name'], ['name' => 'kind'], ['name' => 'description'], ['name' => 'ofType'], ['name' => 'inputFields'], ['name' => 'enumValues'], ['name' => 'fields'], ['name' => 'interfaces'], ['name' => 'possibleTypes']]],
+                                ['name' => 'String', 'fields' => null],
                                 ['name' => '__InputValue', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'type'], ['name' => 'defaultValue'],]],
                                 ['name' => '__EnumValue', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'deprecationReason'], ['name' => 'isDeprecated'],]],
                                 ['name' => 'Boolean', 'fields' => null],
                                 ['name' => '__Field', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'isDeprecated'], ['name' => 'deprecationReason'], ['name' => 'type'], ['name' => 'args']]],
                                 ['name' => '__Subscription', 'fields' => [['name' => 'name']]],
                                 ['name' => '__Directive', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'args'], ['name' => 'onOperation'], ['name' => 'onFragment'], ['name' => 'onField']]],
+                                ['name' => 'Int', 'fields' => null],
+                                ['name' => 'LatestType', 'fields' => [['name' => 'id'], ['name' => 'name']]],
                             ]
                         ]
                     ]

--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -32,15 +32,6 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
     private $_counter = 0;
 
-    /**
-     * @expectedException \Youshido\GraphQL\Validator\Exception\ConfigurationException
-     * @expectedExceptionMessage Schema has to have fields
-     */
-    public function testInit()
-    {
-        new Processor(new TestEmptySchema());
-    }
-
     public function testEmptyQueries()
     {
         $processor = new Processor(new TestSchema());

--- a/Tests/Schema/SchemaTest.php
+++ b/Tests/Schema/SchemaTest.php
@@ -46,7 +46,8 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
     public function testStandaloneEmptySchema()
     {
         $schema = new TestEmptySchema();
-        $this->assertFalse($schema->getQueryType()->hasFields());
+        $this->assertTrue($schema->getQueryType()->hasFields());
+        $this->assertEquals(2, count($schema->getQueryType()->getFields()));
     }
 
     public function testStandaloneSchema()
@@ -76,7 +77,7 @@ class SchemaTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($unserialized->getQueryType()->hasFields());
         $this->assertFalse($unserialized->getMutationType()->hasFields());
-        $this->assertEquals(1, count($unserialized->getQueryType()->getFields()));
+        $this->assertEquals(3, count($unserialized->getQueryType()->getFields()));
     }
 
 }

--- a/examples/01_sandbox/index.php
+++ b/examples/01_sandbox/index.php
@@ -5,10 +5,11 @@ use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema\Schema;
 use Youshido\GraphQL\Type\Object\ObjectType;
 use Youshido\GraphQL\Type\Scalar\StringType;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-$processor = new Processor(new Schema([
+$schema = new Schema([
     'query' => new ObjectType([
         'name'   => 'RootQueryType',
         'fields' => [
@@ -20,7 +21,11 @@ $processor = new Processor(new Schema([
             ]
         ]
     ])
-]));
+]);
+
+(new SchemaValidator())->validate($schema);
+
+$processor = new Processor($schema);
 
 $processor->processPayload('{ currentTime }');
 echo json_encode($processor->getResponseData()) . "\n";

--- a/examples/02_blog/index.php
+++ b/examples/02_blog/index.php
@@ -5,10 +5,13 @@ namespace BlogTest;
 use Examples\Blog\Schema\BlogSchema;
 use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema\Schema;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 require_once __DIR__ . '/schema-bootstrap.php';
 /** @var Schema $schema */
 $schema = new BlogSchema();
+
+(new SchemaValidator())->validate($schema);
 
 $processor = new Processor($schema);
 $payload = 'mutation { likePost(id:5) { title(truncated: false), status, likeCount } }';

--- a/examples/02_blog_inline/index.php
+++ b/examples/02_blog_inline/index.php
@@ -5,15 +5,20 @@ namespace BlogTest;
 use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema\Schema;
 use Youshido\GraphQL\Type\Object\ObjectType;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/inline-schema.php';
 /** @var ObjectType $rootQueryType */
 
-$processor = new Processor(new Schema([
+$schema = new Schema([
     'query' => $rootQueryType
-]));
+]);
+
+(new SchemaValidator())->validate($schema);
+
+$processor = new Processor($schema);
 $payload = '{ latestPost { title(truncated: true), summary } }';
 
 $processor->processPayload($payload);

--- a/examples/03_relay_star_wars/index.php
+++ b/examples/03_relay_star_wars/index.php
@@ -4,10 +4,13 @@ namespace Examples\StarWars;
 
 use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 require_once __DIR__ . '/schema-bootstrap.php';
 /** @var Schema\AbstractSchema $schema */
 $schema = new StarWarsRelaySchema();
+
+(new SchemaValidator())->validate($schema);
 
 $processor = new Processor($schema);
 

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -55,9 +55,6 @@ class Processor
 
     public function __construct(AbstractSchema $schema)
     {
-        (new SchemaValidator())->validate($schema);
-
-        $this->introduceIntrospectionFields($schema);
         $this->executionContext = new ExecutionContext();
         $this->executionContext->setSchema($schema);
 
@@ -398,15 +395,6 @@ class Processor
         }
 
         return $value;
-    }
-
-    protected function introduceIntrospectionFields(AbstractSchema $schema)
-    {
-        $schemaField = new SchemaField();
-        $schemaField->setSchema($schema);
-
-        $schema->addQueryField($schemaField);
-        $schema->addQueryField(new TypeDefinitionField());
     }
 
     public function getResponseData()

--- a/src/Schema/AbstractSchema.php
+++ b/src/Schema/AbstractSchema.php
@@ -10,6 +10,8 @@ namespace Youshido\GraphQL\Schema;
 
 
 use Youshido\GraphQL\Config\Schema\SchemaConfig;
+use Youshido\GraphQL\Introspection\Field\SchemaField;
+use Youshido\GraphQL\Introspection\Field\TypeDefinitionField;
 
 abstract class AbstractSchema
 {
@@ -31,7 +33,11 @@ abstract class AbstractSchema
         $this->build($this->config);
     }
 
-    abstract public function build(SchemaConfig $config);
+    public function build(SchemaConfig $config)
+    {
+        $this->addQueryField(new SchemaField());
+        $this->addQueryField(new TypeDefinitionField());
+    }
 
     public function addQueryField($field, $fieldInfo = null)
     {

--- a/src/Schema/Schema.php
+++ b/src/Schema/Schema.php
@@ -8,11 +8,6 @@
 
 namespace Youshido\GraphQL\Schema;
 
-use Youshido\GraphQL\Config\Schema\SchemaConfig;
-
 final class Schema extends AbstractSchema
 {
-    public function build(SchemaConfig $config)
-    {
-    }
 }


### PR DESCRIPTION
This depends on https://github.com/Youshido/GraphQL/pull/35

Currently, the schema is only final once it has been passed into the Processor. I think it is better to avoid these kind of side-effects inside other classes. The schema should be fully stand-alone and fully initialized before it is passed into the Processor. Schema validation should also happen outside the Processor (I am going to send another PR for that) because it is not necessary to validate the schema on every initialization of the Processor (e.g. think about a scenario where you want to cache the Schema, in that case it would be redundant and ineffective to re-run validation every time. Instead, you want to validate the schema before you cache it!).
