### PR TITLE
Do not validate schema in processor

### DIFF
--- a/examples/01_sandbox/index.php
+++ b/examples/01_sandbox/index.php
@@ -5,22 +5,27 @@ use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema\Schema;
 use Youshido\GraphQL\Type\Object\ObjectType;
 use Youshido\GraphQL\Type\Scalar\StringType;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 
-$processor = new Processor(new Schema([
-    'query' => new ObjectType([
-        'name'   => 'RootQueryType',
-        'fields' => [
-            'currentTime' => [
-                'type'    => new StringType(),
-                'resolve' => function () {
-                    return date('Y-m-d H:ia');
-                }
-            ]
-        ]
-    ])
-]));
+$schema = new Schema([
+  'query' => new ObjectType([
+    'name'   => 'RootQueryType',
+    'fields' => [
+      'currentTime' => [
+        'type'    => new StringType(),
+        'resolve' => function () {
+          return date('Y-m-d H:ia');
+        }
+      ]
+    ]
+  ])
+]);
+
+(new SchemaValidator())->validate($schema);
+
+$processor = new Processor($schema);
 
 $processor->processPayload('{ currentTime }');
 echo json_encode($processor->getResponseData()) . "\n";

--- a/examples/02_blog/index.php
+++ b/examples/02_blog/index.php
@@ -5,10 +5,13 @@ namespace BlogTest;
 use Examples\Blog\Schema\BlogSchema;
 use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema\Schema;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 require_once __DIR__ . '/schema-bootstrap.php';
 /** @var Schema $schema */
 $schema = new BlogSchema();
+
+(new SchemaValidator())->validate($schema);
 
 $processor = new Processor($schema);
 $payload = 'mutation { likePost(id:5) { title(truncated: false), status, likeCount } }';

--- a/examples/02_blog_inline/index.php
+++ b/examples/02_blog_inline/index.php
@@ -5,15 +5,20 @@ namespace BlogTest;
 use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema\Schema;
 use Youshido\GraphQL\Type\Object\ObjectType;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 require_once __DIR__ . '/inline-schema.php';
 /** @var ObjectType $rootQueryType */
 
-$processor = new Processor(new Schema([
-    'query' => $rootQueryType
-]));
+$schema = new Schema([
+  'query' => $rootQueryType
+]);
+
+(new SchemaValidator())->validate($schema);
+
+$processor = new Processor($schema);
 $payload = '{ latestPost { title(truncated: true), summary } }';
 
 $processor->processPayload($payload);

--- a/examples/03_relay_star_wars/index.php
+++ b/examples/03_relay_star_wars/index.php
@@ -4,10 +4,13 @@ namespace Examples\StarWars;
 
 use Youshido\GraphQL\Execution\Processor;
 use Youshido\GraphQL\Schema;
+use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
 require_once __DIR__ . '/schema-bootstrap.php';
 /** @var Schema\AbstractSchema $schema */
 $schema = new StarWarsRelaySchema();
+
+(new SchemaValidator())->validate($schema);
 
 $processor = new Processor($schema);
 

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -55,8 +55,6 @@ class Processor
 
     public function __construct(AbstractSchema $schema)
     {
-        (new SchemaValidator())->validate($schema);
-
         $this->introduceIntrospectionFields($schema);
         $this->executionContext = new ExecutionContext();
         $this->executionContext->setSchema($schema);


### PR DESCRIPTION
Validating the schema in the processor means that, even when the schema is cached, you have to re-validate it although you can guarantee that it is the same as last time you can validation. This should be an implementation detail and part of the application code that integrates with this library.