### PR TITLE
processor returns all fields on objects when no sub-selection given

### DIFF
--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -193,6 +193,9 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         ]);
         $processor = new Processor($schema);
 
+        $processor->processPayload('{ me }');
+        $this->assertArrayHasKey('errors', $processor->getResponseData());
+
         $processor->processPayload('{ me { firstName } }');
         $this->assertEquals(['data' => ['me' => ['firstName' => 'John']]], $processor->getResponseData());
 


### PR DESCRIPTION
Failing test attached.  `me` is an `ObjectType` and thus a query on it must contain a sub-selection.

Expected behavior: an error saying that `me` must contain a sub-selection
Actual behavior: all fields from `me` are returned.

This behavior is contrary to the graphql spec, see the example in http://facebook.github.io/graphql/#sec-Objects