### PR TITLE
Fix invalid content in introspection possibleTypes

### DIFF
--- a/src/Introspection/QueryType.php
+++ b/src/Introspection/QueryType.php
@@ -126,7 +126,7 @@ class QueryType extends AbstractObjectType
 
                     if ($interfaces) {
                         foreach ($interfaces as $interface) {
-                            if (get_class($interface) == get_class($value)) {
+                            if ($interface->getName() == $value->getName()) {
                                 $possibleTypes[] = $type;
                             }
                         }
@@ -134,7 +134,7 @@ class QueryType extends AbstractObjectType
                 }
             }
 
-            return $possibleTypes ?: [];
+            return $possibleTypes;
         } elseif ($value->getKind() == TypeMap::KIND_UNION) {
             /** @var $value AbstractUnionType */
             return $value->getTypes();


### PR DESCRIPTION
Our introspection result contains currently invalid data in possibleTypes in the introspection:
```json
{
                   "possibleTypes": [
                        {
                            "kind": "OBJECT",
                            "name": "Author",
                            "ofType": null
                        },
                        {
                            "kind": "OBJECT",
                            "name": "Author",
                            "ofType": null
                        },
                        {
                            "kind": "OBJECT",
                            "name": "Project",
                            "ofType": null
                        },
                    ]
}
```
We have two interfaces and both show the same possibleTypes, althought this is not true.

* `Project` and `Author` implement `NodeInterface`
* `Author` also implements `PersonInterface`

These happens because in `resolvePossibleTypes()` currently the check assumes that every interface has a different class. But we do not use the OOP way of defining Types (we use annotations and compile them to arrays). So the class is always `Youshido\GraphQL\Type\InterfaceTypeInterfaceType`.

Changing the check to use names fixes the issue, and names have to be unique anyway I think. (Although I noticed that having two objecttypes with the same name does not yield an error, but corrupts the schema).

After the change the possibleTypes are correct.
Also removed the ternary operator as `$possibleTypes` is always an array.