### PR TITLE
use json_encode to resolve defaultValue for args

### DIFF
--- a/Tests/Library/Field/InputFieldTest.php
+++ b/Tests/Library/Field/InputFieldTest.php
@@ -32,7 +32,7 @@ class InputFieldTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('id', $field->getName());
         $this->assertEquals(new IdType(), $field->getType());
         $this->assertEquals('description', $field->getDescription());
-        $this->assertEquals(123, $field->getDefaultValue());
+        $this->assertSame(123, $field->getDefaultValue());
     }
 
 

--- a/Tests/Schema/IntrospectionTest.php
+++ b/Tests/Schema/IntrospectionTest.php
@@ -130,7 +130,8 @@ TEXT;
                 ],
             ]),
             'args'              => [
-                'id' => ['type' => TypeMap::TYPE_INT]
+                'id' => ['type' => TypeMap::TYPE_INT, 'default' => 'test'],
+                'id2' => ['type' => TypeMap::TYPE_INT]
             ],
             'description'       => 'latest description',
             'deprecationReason' => 'for test',
@@ -183,6 +184,9 @@ TEXT;
                             name,
                             fields (includeDeprecated: true) {
                                 name
+                                args {
+                                    defaultValue
+                                }
                             }
                         }
                     }
@@ -191,18 +195,18 @@ TEXT;
                     'data' => [
                         '__schema' => [
                             'types' => [
-                                ['name' => 'TestSchemaQuery', 'fields' => [['name' => 'latest']]],
+                                ['name' => 'TestSchemaQuery', 'fields' => [['name' => 'latest', 'args' => [['defaultValue' => '"test"'], ['defaultValue' => null]]]]],
                                 ['name' => 'Int', 'fields' => null],
-                                ['name' => 'LatestType', 'fields' => [['name' => 'id'], ['name' => 'name']]],
+                                ['name' => 'LatestType', 'fields' => [['name' => 'id', 'args' => []], ['name' => 'name', 'args' => []]]],
                                 ['name' => 'String', 'fields' => null],
-                                ['name' => '__Schema', 'fields' => [['name' => 'queryType'], ['name' => 'mutationType'], ['name' => 'subscriptionType'], ['name' => 'types'], ['name' => 'directives']]],
-                                ['name' => '__Type', 'fields' => [['name' => 'name'], ['name' => 'kind'], ['name' => 'description'], ['name' => 'ofType'], ['name' => 'inputFields'], ['name' => 'enumValues'], ['name' => 'fields'], ['name' => 'interfaces'], ['name' => 'possibleTypes']]],
-                                ['name' => '__InputValue', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'type'], ['name' => 'defaultValue'],]],
+                                ['name' => '__Schema', 'fields' => [['name' => 'queryType', 'args' => []], ['name' => 'mutationType', 'args' => []], ['name' => 'subscriptionType', 'args' => []], ['name' => 'types', 'args' => []], ['name' => 'directives', 'args' => []]]],
+                                ['name' => '__Type', 'fields' => [['name' => 'name', 'args' => []], ['name' => 'kind', 'args' => []], ['name' => 'description', 'args' => []], ['name' => 'ofType', 'args' => []], ['name' => 'inputFields', 'args' => []], ['name' => 'enumValues', 'args' => [['defaultValue' => 'false']]], ['name' => 'fields', 'args' => [['defaultValue' => 'false']]], ['name' => 'interfaces', 'args' => []], ['name' => 'possibleTypes', 'args' => []]]],
+                                ['name' => '__InputValue', 'fields' => [['name' => 'name', 'args' => []], ['name' => 'description', 'args' => []], ['name' => 'type', 'args' => []], ['name' => 'defaultValue', 'args' => []],]],
                                 ['name' => 'Boolean', 'fields' => null],
-                                ['name' => '__EnumValue', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'deprecationReason'], ['name' => 'isDeprecated'],]],
-                                ['name' => '__Field', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'isDeprecated'], ['name' => 'deprecationReason'], ['name' => 'type'], ['name' => 'args']]],
-                                ['name' => '__Subscription', 'fields' => [['name' => 'name']]],
-                                ['name' => '__Directive', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'args'], ['name' => 'onOperation'], ['name' => 'onFragment'], ['name' => 'onField']]],
+                                ['name' => '__EnumValue', 'fields' => [['name' => 'name', 'args' => []], ['name' => 'description', 'args' => []], ['name' => 'deprecationReason', 'args' => []], ['name' => 'isDeprecated', 'args' => []],]],
+                                ['name' => '__Field', 'fields' => [['name' => 'name', 'args' => []], ['name' => 'description', 'args' => []], ['name' => 'isDeprecated', 'args' => []], ['name' => 'deprecationReason', 'args' => []], ['name' => 'type', 'args' => []], ['name' => 'args', 'args' => []]]],
+                                ['name' => '__Subscription', 'fields' => [['name' => 'name', 'args' => []]]],
+                                ['name' => '__Directive', 'fields' => [['name' => 'name', 'args' => []], ['name' => 'description', 'args' => []], ['name' => 'args', 'args' => []], ['name' => 'onOperation', 'args' => []], ['name' => 'onFragment', 'args' => []], ['name' => 'onField', 'args' => []]]],
                             ]
                         ]
                     ]

--- a/src/Introspection/InputValueType.php
+++ b/src/Introspection/InputValueType.php
@@ -7,36 +7,55 @@
 
 namespace Youshido\GraphQL\Introspection;
 
-
 use Youshido\GraphQL\Field\Field;
 use Youshido\GraphQL\Schema\AbstractSchema;
+use Youshido\GraphQL\Type\NonNullType;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
+use Youshido\GraphQL\Type\TypeInterface;
 use Youshido\GraphQL\Type\TypeMap;
 
 class InputValueType extends AbstractObjectType
 {
-
+    /**
+     * @param AbstractSchema|Field $value
+     *
+     * @return TypeInterface
+     */
     public function resolveType($value)
     {
-        /** @var AbstractSchema|Field $value */
         return $value->getConfig()->getType();
+    }
+
+    /**
+     * @param AbstractSchema|Field $value
+     *
+     * @return string|null
+     */
+    public function resolveDefaultValue($value)
+    {
+        $resolvedValue = $value->getConfig()->getDefaultValue();
+
+        return $resolvedValue === null ? $resolvedValue : json_encode($resolvedValue);
     }
 
     public function build($config)
     {
         $config
-            ->addField('name', TypeMap::TYPE_STRING)
+            ->addField('name', new NonNullType(TypeMap::TYPE_STRING))
             ->addField('description', TypeMap::TYPE_STRING)
             ->addField(new Field([
                 'name'    => 'type',
-                'type'    => new QueryType(),
+                'type'    => new NonNullType(new QueryType()),
                 'resolve' => [$this, 'resolveType']
             ]))
-            ->addField('defaultValue', TypeMap::TYPE_STRING);
+            ->addField('defaultValue', [
+                'type' => TypeMap::TYPE_STRING,
+                'resolve' => [$this, 'resolveDefaultValue']
+            ]);
     }
 
     /**
-     * @return String type name
+     * @return string type name
      */
     public function getName()
     {


### PR DESCRIPTION
The spec clearly says that the defaultValue is a string representation of the value. 
http://facebook.github.io/graphql/#sec-The-__InputValue-Type

Currently this library puts the plain value (int, bool, string) as defaultValue.

By looking at other implementations this is how values are converted:

```
1 => '1'
'1' => '"1"'
null => null
false => 'false'
```

I'm not sure if the place where I fixed it is correct, but the test should be correct.

Without this fix relay and graphql-js both choke on the exported introspection schema.