### PR TITLE
Correct Schema for FieldType and fix NonNullable with List

### DIFF
--- a/Tests/Schema/IntrospectionTest.php
+++ b/Tests/Schema/IntrospectionTest.php
@@ -143,6 +143,14 @@ TEXT;
             }
         ]));
 
+        $schema->addQueryField(new Field([
+            'name'              => 'new',
+            'type'              => TypeMap::TYPE_BOOLEAN,
+            'resolve'           => function () {
+                return true;
+            }
+        ]));
+
         $processor = new Processor($schema);
 
         $processor->processPayload($query);
@@ -191,14 +199,14 @@ TEXT;
                     'data' => [
                         '__schema' => [
                             'types' => [
-                                ['name' => 'TestSchemaQuery', 'fields' => [['name' => 'latest']]],
+                                ['name' => 'TestSchemaQuery', 'fields' => [['name' => 'latest'], ['name' => 'new']]],
                                 ['name' => 'Int', 'fields' => null],
                                 ['name' => 'LatestType', 'fields' => [['name' => 'id'], ['name' => 'name']]],
                                 ['name' => 'String', 'fields' => null],
+                                ['name' => 'Boolean', 'fields' => null],
                                 ['name' => '__Schema', 'fields' => [['name' => 'queryType'], ['name' => 'mutationType'], ['name' => 'subscriptionType'], ['name' => 'types'], ['name' => 'directives']]],
                                 ['name' => '__Type', 'fields' => [['name' => 'name'], ['name' => 'kind'], ['name' => 'description'], ['name' => 'ofType'], ['name' => 'inputFields'], ['name' => 'enumValues'], ['name' => 'fields'], ['name' => 'interfaces'], ['name' => 'possibleTypes']]],
                                 ['name' => '__InputValue', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'type'], ['name' => 'defaultValue'],]],
-                                ['name' => 'Boolean', 'fields' => null],
                                 ['name' => '__EnumValue', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'deprecationReason'], ['name' => 'isDeprecated'],]],
                                 ['name' => '__Field', 'fields' => [['name' => 'name'], ['name' => 'description'], ['name' => 'isDeprecated'], ['name' => 'deprecationReason'], ['name' => 'type'], ['name' => 'args']]],
                                 ['name' => '__Subscription', 'fields' => [['name' => 'name']]],
@@ -232,7 +240,8 @@ TEXT;
                             'name'   => 'TestSchemaQuery',
                             'kind'   => 'OBJECT',
                             'fields' => [
-                                ['name' => 'latest', 'isDeprecated' => true, 'deprecationReason' => 'for test', 'description' => 'latest description', 'type' => ['name' => 'LatestType']]
+                                ['name' => 'latest', 'isDeprecated' => true, 'deprecationReason' => 'for test', 'description' => 'latest description', 'type' => ['name' => 'LatestType']],
+                                ['name' => 'new', 'isDeprecated' => false, 'deprecationReason' => null, 'description' => null, 'type' => ['name' => 'Boolean']]
                             ]
                         ]
                     ]

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -166,8 +166,13 @@ class Processor
 
         $fieldType = $this->resolveValidator->resolveTypeIfAbstract($fieldType, $resolvedValue);
         $value     = [];
+        $kind      = $fieldType->getKind();
 
-        if ($fieldType->getKind() == TypeMap::KIND_LIST) {
+        if (
+            $kind === TypeMap::KIND_LIST ||
+            ($kind === TypeMap::KIND_NON_NULL && $fieldType->getNamedType()->getKind() === TypeMap::KIND_LIST)
+        ) {
+            if ($kind === TypeMap::KIND_NON_NULL) $fieldType = $fieldType->getNamedType();
             if (!$this->resolveValidator->hasArrayAccess($resolvedValue)) return null;
 
             $namedType          = $fieldType->getNamedType();

--- a/src/Introspection/FieldType.php
+++ b/src/Introspection/FieldType.php
@@ -9,6 +9,7 @@ namespace Youshido\GraphQL\Introspection;
 
 use Youshido\GraphQL\Field\AbstractField;
 use Youshido\GraphQL\Type\ListType\ListType;
+use Youshido\GraphQL\Type\NonNullType;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 use Youshido\GraphQL\Type\TypeMap;
 
@@ -32,16 +33,16 @@ class FieldType extends AbstractObjectType
     public function build($config)
     {
         $config
-            ->addField('name', TypeMap::TYPE_STRING)
+            ->addField('name', new NonNullType(TypeMap::TYPE_STRING))
             ->addField('description', TypeMap::TYPE_STRING)
-            ->addField('isDeprecated', TypeMap::TYPE_BOOLEAN)
+            ->addField('isDeprecated', new NonNullType(TypeMap::TYPE_BOOLEAN))
             ->addField('deprecationReason', TypeMap::TYPE_STRING)
             ->addField('type', [
-                'type'    => new QueryType(),
+                'type'    => new NonNullType(new QueryType()),
                 'resolve' => [$this, 'resolveType'],
             ])
             ->addField('args', [
-                'type'    => new ListType(new InputValueType()),
+                'type'    => new NonNullType(new ListType(new NonNullType(new InputValueType()))),
                 'resolve' => [$this, 'resolveArgs'],
             ]);
     }


### PR DESCRIPTION
NonNullable together with ListType was not working, because the processor
was only doing the list logic if the outer type was a list ([see here](https://github.com/Youshido/GraphQL/blob/master/src/Execution/Processor.php#L170))
and was not accounting for NonNullable

Also the fields `name`, `isDeprecated`, `type` and `args` are currently nullable, but the should be non nullable, so I changed them to NonNullable

From the spec:

```
type __Field {
  name: String!
  description: String
  args: [__InputValue!]!
  type: __Type!
  isDeprecated: Boolean!
  deprecationReason: String
}
```

I'm not sure if this is the correct solution, maybe composite types should report the kind of their inner type, but then other parts of the lib would need to be refactored.

the changes in the tests check that `isDeprecated` is always a boolean even if not set (was `null` before). For `args` it was correct before and it is already tested.

Probably also all the other fields of IntrospectionTypes should be revisited and checked, as a lot of them are NonNullable. Should I do that and add PRs?

I'm also in the gitter channel, feel free to chat me there.
