### PR TITLE
Use FieldInterface instead of AbstractField 

### DIFF
--- a/src/Config/Traits/FieldsAwareConfigTrait.php
+++ b/src/Config/Traits/FieldsAwareConfigTrait.php
@@ -9,7 +9,6 @@
 namespace Youshido\GraphQL\Config\Traits;
 
 
-use Youshido\GraphQL\Field\AbstractField;
 use Youshido\GraphQL\Field\Field;
 use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Type\InterfaceType\AbstractInterfaceType;
@@ -61,7 +60,7 @@ trait FieldsAwareConfigTrait
     }
 
     /**
-     * @param AbstractField|string $field     Field name or Field Object
+     * @param FieldInterface|string $field     Field name or Field Object
      * @param mixed                $fieldInfo Field Type or Field Config array
      * @return $this
      */

--- a/src/Config/Traits/ResolvableObjectTrait.php
+++ b/src/Config/Traits/ResolvableObjectTrait.php
@@ -1,0 +1,46 @@
+<?php
+/*
+* This file is a part of graphql-youshido project.
+*
+* @author Philipp Melab <philipp.melab@gmail.com>
+*/
+
+namespace Youshido\GraphQL\Config\Traits;
+
+use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Type\TypeMap;
+use Youshido\GraphQL\Type\TypeService;
+
+trait ResolvableObjectTrait {
+
+  public function resolve($value, array $args, ResolveInfo $info)
+  {
+    if ($this->resolveFunctionCache === null) {
+      $this->resolveFunctionCache = $this->getConfig()->getResolveFunction();
+
+      if (!$this->resolveFunctionCache) {
+        $this->resolveFunctionCache = false;
+      }
+    }
+    if ($this->resolveFunctionCache) {
+      $resolveFunction = $this->resolveFunctionCache;
+
+      return $resolveFunction($value, $args, $info);
+    } else {
+      if (is_array($value) && array_key_exists($this->getName(), $value)) {
+        return $value[$this->getName()];
+      } elseif (is_object($value)) {
+        return TypeService::getPropertyValue($value, $this->getName());
+      } elseif ($this->getType()->getNamedType()->getKind() == TypeMap::KIND_SCALAR) {
+        return null;
+      } else {
+        throw new \Exception(sprintf('Property "%s" not found in resolve result', $this->getName()));
+      }
+    }
+  }
+
+
+  public function getResolveFunction() {
+    return $this->getConfig()->getResolveFunction();
+  }
+}

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -13,8 +13,8 @@ use Youshido\GraphQL\Execution\Container\Container;
 use Youshido\GraphQL\Execution\Context\ExecutionContext;
 use Youshido\GraphQL\Execution\Visitor\AbstractQueryVisitor;
 use Youshido\GraphQL\Execution\Visitor\MaxComplexityQueryVisitor;
-use Youshido\GraphQL\Field\AbstractField;
 use Youshido\GraphQL\Field\Field;
+use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Parser\Ast\Field as FieldAst;
 use Youshido\GraphQL\Parser\Ast\Fragment;
 use Youshido\GraphQL\Parser\Ast\FragmentInterface;
@@ -114,7 +114,7 @@ class Processor
             return null;
         }
 
-        /** @var AbstractField $field */
+        /** @var FieldInterface $field */
         $operationField = $currentLevelSchema->getField($query->getName());
         $alias          = $query->getAlias() ?: $query->getName();
 
@@ -127,11 +127,11 @@ class Processor
 
     /**
      * @param Query         $query
-     * @param AbstractField $field
+     * @param FieldInterface $field
      * @param               $contextValue
      * @return array|mixed|null
      */
-    protected function processQueryAST(Query $query, AbstractField $field, $contextValue = null)
+    protected function processQueryAST(Query $query, FieldInterface $field, $contextValue = null)
     {
         if (!$this->resolveValidator->validateArguments($field, $query, $this->executionContext->getRequest())) {
             return null;
@@ -207,14 +207,14 @@ class Processor
 
     /**
      * @param FieldAst      $fieldAst
-     * @param AbstractField $field
+     * @param FieldInterface $field
      *
      * @param mixed         $contextValue
      * @return array|mixed|null
      * @throws ResolveException
      * @throws \Exception
      */
-    protected function processFieldAST(FieldAst $fieldAst, AbstractField $field, $contextValue)
+    protected function processFieldAST(FieldAst $fieldAst, FieldInterface $field, $contextValue)
     {
         $value            = null;
         $fieldType        = $field->getType();
@@ -244,13 +244,13 @@ class Processor
     /**
      * @param               $contextValue
      * @param FieldAst      $fieldAst
-     * @param AbstractField $field
+     * @param FieldInterface $field
      *
      * @throws \Exception
      *
      * @return mixed
      */
-    protected function getPreResolvedValue($contextValue, FieldAst $fieldAst, AbstractField $field)
+    protected function getPreResolvedValue($contextValue, FieldAst $fieldAst, FieldInterface $field)
     {
         if ($field->hasArguments() && !$this->resolveValidator->validateArguments($field, $fieldAst, $this->executionContext->getRequest())) {
             throw new \Exception(sprintf('Not valid arguments for the field "%s"', $fieldAst->getName()));
@@ -260,18 +260,18 @@ class Processor
 
     }
 
-    protected function resolveFieldValue(AbstractField $field, $contextValue, array $fields, array $args)
+    protected function resolveFieldValue(FieldInterface $field, $contextValue, array $fields, array $args)
     {
         return $field->resolve($contextValue, $args, $this->createResolveInfo($field, $fields));
     }
 
     /**
-     * @param $field     AbstractField
+     * @param $field     FieldInterface
      * @param $query     Query
      *
      * @return array
      */
-    protected function parseArgumentsValues(AbstractField $field, Query $query)
+    protected function parseArgumentsValues(FieldInterface $field, Query $query)
     {
         $args = [];
         foreach ($query->getArguments() as $argument) {
@@ -354,7 +354,7 @@ class Processor
         return $value;
     }
 
-    protected function getFieldValidatedValue(AbstractField $field, $value)
+    protected function getFieldValidatedValue(FieldInterface $field, $value)
     {
         return ($this->resolveValidator->isValidValueForField($field, $value)) ? $this->getOutputValue($field->getType(), $value) : null;
     }
@@ -463,11 +463,11 @@ class Processor
      * case of a Field and yield that back up to the visitor up in `doVisit`.
      *
      * @param Query|Field|FragmentInterface $queryNode
-     * @param AbstractField                 $currentLevelAST
+     * @param FieldInterface                 $currentLevelAST
      *
      * @return \Generator
      */
-    protected function walkQuery($queryNode, AbstractField $currentLevelAST)
+    protected function walkQuery($queryNode, FieldInterface $currentLevelAST)
     {
         $childrenScore = 0;
         if (!($queryNode instanceof FieldAst)) {

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -275,7 +275,7 @@ class Processor
     {
         $args = [];
         foreach ($query->getArguments() as $argument) {
-            if ($configArgument = $field->getConfig()->getArgument($argument->getName())) {
+            if ($configArgument = $field->getArgument($argument->getName())) {
                 $args[$argument->getName()] = $configArgument->getType()->parseValue($argument->getValue()->getValue());
             }
         }

--- a/src/Execution/ResolveInfo.php
+++ b/src/Execution/ResolveInfo.php
@@ -10,12 +10,13 @@ namespace Youshido\GraphQL\Execution;
 
 use Youshido\GraphQL\Execution\Context\ExecutionContextInterface;
 use Youshido\GraphQL\Field\AbstractField;
+use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Parser\Ast\Field;
 use Youshido\GraphQL\Type\AbstractType;
 
 class ResolveInfo
 {
-    /** @var  AbstractField */
+    /** @var  FieldInterface */
     protected $field;
 
     /** @var Field[] */
@@ -33,7 +34,7 @@ class ResolveInfo
      */
     protected $container;
 
-    public function __construct(AbstractField $field, array $fieldASTList, ExecutionContextInterface $executionContext)
+    public function __construct(FieldInterface $field, array $fieldASTList, ExecutionContextInterface $executionContext)
     {
         $this->field            = $field;
         $this->fieldASTList     = $fieldASTList;
@@ -49,7 +50,7 @@ class ResolveInfo
     }
 
     /**
-     * @return AbstractField
+     * @return FieldInterface
      */
     public function getField()
     {

--- a/src/Field/AbstractField.php
+++ b/src/Field/AbstractField.php
@@ -8,19 +8,19 @@
 namespace Youshido\GraphQL\Field;
 
 use Youshido\GraphQL\Config\Field\FieldConfig;
-use Youshido\GraphQL\Execution\ResolveInfo;
+use Youshido\GraphQL\Config\Traits\ResolvableObjectTrait;
 use Youshido\GraphQL\Type\AbstractType;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 use Youshido\GraphQL\Type\Traits\AutoNameTrait;
 use Youshido\GraphQL\Type\Traits\FieldsArgumentsAwareObjectTrait;
 use Youshido\GraphQL\Type\TypeFactory;
-use Youshido\GraphQL\Type\TypeMap;
 use Youshido\GraphQL\Type\TypeService;
 
 abstract class AbstractField implements FieldInterface
 {
 
     use FieldsArgumentsAwareObjectTrait;
+    use ResolvableObjectTrait;
     use AutoNameTrait {
         getName as getAutoName;
     }
@@ -60,32 +60,6 @@ abstract class AbstractField implements FieldInterface
     public function setType($type)
     {
         $this->getConfig()->set('type', $type);
-    }
-
-    public function resolve($value, array $args, ResolveInfo $info)
-    {
-        if ($this->resolveFunctionCache === null) {
-            $this->resolveFunctionCache = $this->getConfig()->getResolveFunction();
-
-            if (!$this->resolveFunctionCache) {
-                $this->resolveFunctionCache = false;
-            }
-        }
-        if ($this->resolveFunctionCache) {
-            $resolveFunction = $this->resolveFunctionCache;
-
-            return $resolveFunction($value, $args, $info);
-        } else {
-            if (is_array($value) && array_key_exists($this->getName(), $value)) {
-                return $value[$this->getName()];
-            } elseif (is_object($value)) {
-                return TypeService::getPropertyValue($value, $this->getName());
-            } elseif ($this->getType()->getNamedType()->getKind() == TypeMap::KIND_SCALAR) {
-                return null;
-            } else {
-                throw new \Exception(sprintf('Property "%s" not found in resolve result', $this->getName()));
-            }
-        }
     }
 
     public function getName()

--- a/src/Field/AbstractInputField.php
+++ b/src/Field/AbstractInputField.php
@@ -9,6 +9,7 @@ namespace Youshido\GraphQL\Field;
 
 
 use Youshido\GraphQL\Config\Field\InputFieldConfig;
+use Youshido\GraphQL\Config\Traits\ResolvableObjectTrait;
 use Youshido\GraphQL\Type\InputObject\AbstractInputObjectType;
 use Youshido\GraphQL\Type\Traits\AutoNameTrait;
 use Youshido\GraphQL\Type\Traits\FieldsArgumentsAwareObjectTrait;
@@ -18,7 +19,7 @@ use Youshido\GraphQL\Type\TypeService;
 abstract class AbstractInputField implements FieldInterface
 {
 
-    use FieldsArgumentsAwareObjectTrait, AutoNameTrait;
+    use FieldsArgumentsAwareObjectTrait, AutoNameTrait, ResolvableObjectTrait;
 
     protected $isFinal = false;
 

--- a/src/Field/FieldInterface.php
+++ b/src/Field/FieldInterface.php
@@ -8,6 +8,7 @@
 namespace Youshido\GraphQL\Field;
 
 
+use Youshido\GraphQL\Execution\ResolveInfo;
 use Youshido\GraphQL\Type\AbstractType;
 
 interface FieldInterface
@@ -18,4 +19,34 @@ interface FieldInterface
     public function getType();
 
     public function getName();
+
+    public function addArguments($argumentsList);
+
+    public function removeArgument($argumentName);
+
+    public function addArgument($argument, $ArgumentInfo = null);
+
+    /**
+     * @return AbstractType[]
+     */
+    public function getArguments();
+
+    /**
+     * @return AbstractType
+     */
+    public function getArgument($argumentName);
+
+    /**
+     * @return boolean
+     */
+    public function hasArgument($argumentName);
+
+    /**
+     * @return boolean
+     */
+    public function hasArguments();
+
+    public function resolve($value, array $args, ResolveInfo $info);
+
+    public function getResolveFunction();
 }

--- a/src/Introspection/FieldType.php
+++ b/src/Introspection/FieldType.php
@@ -8,6 +8,7 @@
 namespace Youshido\GraphQL\Introspection;
 
 use Youshido\GraphQL\Field\AbstractField;
+use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Type\ListType\ListType;
 use Youshido\GraphQL\Type\Object\AbstractObjectType;
 use Youshido\GraphQL\Type\TypeMap;
@@ -15,15 +16,15 @@ use Youshido\GraphQL\Type\TypeMap;
 class FieldType extends AbstractObjectType
 {
 
-    public function resolveType(AbstractField $value)
+    public function resolveType(FieldInterface $value)
     {
         return $value->getType();
     }
 
-    public function resolveArgs(AbstractField $value)
+    public function resolveArgs(FieldInterface $value)
     {
-        if ($value->getConfig()->hasArguments()) {
-            return $value->getConfig()->getArguments();
+        if ($value->hasArguments()) {
+            return $value->getArguments();
         }
 
         return [];
@@ -48,7 +49,7 @@ class FieldType extends AbstractObjectType
 
     public function isValidValue($value)
     {
-        return $value instanceof AbstractField;
+        return $value instanceof FieldInterface;
     }
 
     /**

--- a/src/Type/Traits/AutoNameTrait.php
+++ b/src/Type/Traits/AutoNameTrait.php
@@ -7,7 +7,7 @@
 */
 
 namespace Youshido\GraphQL\Type\Traits;
-use Youshido\GraphQL\Field\AbstractField;
+use Youshido\GraphQL\Field\FieldInterface;
 
 /**
  * Class AutoNameTrait
@@ -33,7 +33,7 @@ trait AutoNameTrait
             $className = substr($className, 0, -4);
         }
 
-        if ($this instanceof AbstractField) {
+        if ($this instanceof FieldInterface) {
             $className = lcfirst($className);
         }
 

--- a/src/Validator/ConfigValidator/Rules/TypeValidationRule.php
+++ b/src/Validator/ConfigValidator/Rules/TypeValidationRule.php
@@ -9,8 +9,8 @@
 namespace Youshido\GraphQL\Validator\ConfigValidator\Rules;
 
 
-use Youshido\GraphQL\Field\AbstractField;
 use Youshido\GraphQL\Field\AbstractInputField;
+use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Type\AbstractType;
 use Youshido\GraphQL\Type\TypeFactory;
 use Youshido\GraphQL\Type\TypeService;
@@ -140,7 +140,7 @@ class TypeValidationRule implements ValidationRuleInterface
     private function isField($data, $name = null)
     {
         if (is_object($data)) {
-            return ($data instanceof AbstractField) || ($data instanceof AbstractType);
+            return ($data instanceof FieldInterface) || ($data instanceof AbstractType);
         }
         if (!is_array($data)) {
             $data = [

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -9,7 +9,7 @@ namespace Youshido\GraphQL\Validator\ResolveValidator;
 
 use Youshido\GraphQL\Execution\Context\ExecutionContextInterface;
 use Youshido\GraphQL\Execution\Request;
-use Youshido\GraphQL\Field\AbstractField;
+use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Field\InputField;
 use Youshido\GraphQL\Parser\Ast\Argument;
 use Youshido\GraphQL\Parser\Ast\ArgumentValue\Literal;
@@ -20,7 +20,6 @@ use Youshido\GraphQL\Parser\Ast\FragmentReference;
 use Youshido\GraphQL\Parser\Ast\Mutation;
 use Youshido\GraphQL\Parser\Ast\Query;
 use Youshido\GraphQL\Type\AbstractType;
-use Youshido\GraphQL\Type\CompositeTypeInterface;
 use Youshido\GraphQL\Type\InputObject\AbstractInputObjectType;
 use Youshido\GraphQL\Type\InterfaceType\AbstractInterfaceType;
 use Youshido\GraphQL\Type\ListType\AbstractListType;
@@ -60,7 +59,7 @@ class ResolveValidator implements ResolveValidatorInterface
     /**
      * @inheritdoc
      */
-    public function validateArguments(AbstractField $field, $query, Request $request)
+    public function validateArguments(FieldInterface $field, $query, Request $request)
     {
         $requiredArguments = array_filter($field->getArguments(), function (InputField $argument) {
             return $argument->getType()->getKind() == TypeMap::KIND_NON_NULL;
@@ -188,7 +187,7 @@ class ResolveValidator implements ResolveValidatorInterface
         return is_array($data) || $data instanceof \Traversable;
     }
 
-    public function isValidValueForField(AbstractField $field, $value)
+    public function isValidValueForField(FieldInterface $field, $value)
     {
         $fieldType = $field->getType();
         if ($fieldType->getKind() == TypeMap::KIND_NON_NULL && is_null($value)) {

--- a/src/Validator/ResolveValidator/ResolveValidatorInterface.php
+++ b/src/Validator/ResolveValidator/ResolveValidatorInterface.php
@@ -9,7 +9,7 @@ namespace Youshido\GraphQL\Validator\ResolveValidator;
 
 
 use Youshido\GraphQL\Execution\Request;
-use Youshido\GraphQL\Field\AbstractField;
+use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Parser\Ast\Field;
 use Youshido\GraphQL\Parser\Ast\Query;
 
@@ -17,12 +17,12 @@ interface ResolveValidatorInterface
 {
 
     /**
-     * @param $field     AbstractField
+     * @param $field     FieldInterface
      * @param $query     Query|Field
      * @param $request   Request
      *
      * @return bool
      */
-    public function validateArguments(AbstractField $field, $query, Request $request);
+    public function validateArguments(FieldInterface $field, $query, Request $request);
 
 }


### PR DESCRIPTION
Removed usages of AbstractField (except extends) in favour of FieldInterface to loose coupling between Processor and Field implementations. 
Extended FieldInterface with necessary methods.