### PR TITLE
Integer variables causes many crash

### DIFF
--- a/Tests/Library/Validator/ResolveValidatorTest.php
+++ b/Tests/Library/Validator/ResolveValidatorTest.php
@@ -217,6 +217,11 @@ class ResolveValidatorTest extends \PHPUnit_Framework_TestCase
         $validator->validateArguments($field, $argumentWithVariable, $request);
         $this->assertFalse($validator->getExecutionContext()->hasErrors());
 
+        $request->setVariables(['year' => 0]);
+        $validator->validateArguments($field, $argumentWithVariable, $request);
+        $this->assertFalse($validator->getExecutionContext()->hasErrors());
+        $request->setVariables([]);
+
         $validator->validateArguments($field, $argumentWithVariableWrongType, $request);
         $this->assertEquals([
             ['message' => 'Invalid variable "year" type, allowed type is "Int"']

--- a/Tests/Parser/RequestTest.php
+++ b/Tests/Parser/RequestTest.php
@@ -50,4 +50,17 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($request->getFragment('unknown fragment'));
     }
 
+    public function testSetVariableParseJson()
+    {
+        $variables = '{"foo": "bar"}';
+        $expectedVariableArray = [ 'foo' => 'bar' ];
+
+        $request = new Request([], $variables);
+        $this->assertEquals($expectedVariableArray, $request->getVariables());
+
+        $request = new Request();
+        $request->setVariables($variables);
+        $this->assertEquals($expectedVariableArray, $request->getVariables());
+    }
+
 }

--- a/Tests/Parser/VariableTest.php
+++ b/Tests/Parser/VariableTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Youshido\Tests\Parser;
+
+use Youshido\GraphQL\Parser\Ast\ArgumentValue\Variable;
+
+class VariableTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test if variable value equals expected value
+     *
+     * @dataProvider variableProvider
+     */
+    public function testGetValue($actual, $expected)
+    {
+        $var = new Variable('foo', 'bar');
+        $var->setValue($actual);
+        $this->assertEquals($var->getValue(), $expected);
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Value is not set for variable "foo"
+     */
+    public function testGetNullValueException()
+    {
+        $var = new Variable('foo', 'bar');
+        $var->getValue();
+    }
+
+    /**
+     * @return array Array of <mixed: value to set, mixed: expected value>
+     */
+    public static function variableProvider()
+    {
+        return [
+            [
+                0,
+                0
+            ]
+        ];
+    }
+}

--- a/src/Execution/Request.php
+++ b/src/Execution/Request.php
@@ -152,6 +152,10 @@ class Request
      */
     public function setVariables($variables)
     {
+        if (!is_array($variables)) {
+            $variables = json_decode($variables, true);
+        }
+
         $this->variables = $variables;
 
         return $this;

--- a/src/Parser/Ast/ArgumentValue/Variable.php
+++ b/src/Parser/Ast/ArgumentValue/Variable.php
@@ -40,7 +40,7 @@ class Variable implements ValueInterface
      */
     public function getValue()
     {
-        if (!$this->value) {
+        if (null === $this->value) {
             throw new \LogicException('Value is not set for variable "' . $this->name . '"');
         }
 

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -94,7 +94,7 @@ class ResolveValidator implements ResolveValidatorInterface
 
                 /** @var Variable $requestVariable */
                 $requestVariable = $request->getVariable($variable->getName());
-                if (!$requestVariable) {
+                if (null === $requestVariable) {
                     $this->executionContext->addError(new ResolveException(sprintf('Variable "%s" does not exist for query "%s"', $argument->getName(), $field->getName())));
 
                     return false;


### PR DESCRIPTION
Considering following query 

```javascript
query ($limit: Int!, $offset: Int!) {
    postList(__limit: $limit, __offset: $offset) {
        title
        slug
    }
}
```

And following variables

```json
{"limit": 1, "offset": 0}
```

There are multiples bad type check which cause issues with integer values as PHP evaluate directly integer values as boolean ... We need to strict test `null` values !

Also add an array cast for json values in `Request::setVariables()`. Dunno if it's the right fix for this last one.