### PR TITLE
add test for a Nullable InputObject with a NonNullable field

### DIFF
--- a/Tests/Library/Type/InputObjectTypeTest.php
+++ b/Tests/Library/Type/InputObjectTypeTest.php
@@ -98,6 +98,48 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testNullableInputWithNonNull(){
+        $processor = new Processor(new Schema([
+            'query'    => new ObjectType([
+                'name'   => 'RootQuery',
+                'fields' => [
+                    'empty' => [
+                        'type'    => new StringType(),
+                        'resolve' => function () {
+                            return null;
+                        }
+                    ]
+                ]
+            ]),
+            'mutation' => new ObjectType([
+                'name'   => 'RootMutation',
+                'fields' => [
+                    'createAuthor' => [
+                        'args'    => [
+                            'author' => new InputObjectType([
+                                'name'   => 'AuthorInputType',
+                                'fields' => [
+                                    'name' => new NonNullType(new StringType()),
+                                ]
+                            ])
+                        ],
+                        'type'    => new BooleanType(),
+                        'resolve' => function ($object, $args) {
+                            return true;
+                        }
+                    ]
+                ]
+            ])
+        ]));
+        $processor->processPayload('mutation { createAuthor(author: null) }');
+        $this->assertEquals(
+            [
+                'data'   => ['createAuthor' => true],
+            ],
+            $processor->getResponseData()
+        );
+    }
+
     public function testListInsideInputObject()
     {
         $processor = new Processor(new Schema([


### PR DESCRIPTION
I'm having trouble with setting an InputObject to null if it has a field that is not nullable.

In the test author is an inputobject with a nonnullable field name, but author itself is nullable.

It however gives an error.