### PR TITLE
More realistic GraphQL vs REST explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,17 @@
 
 This is a pure PHP realization of the GraphQL protocol based on the working draft of the official GraphQL Specification located on http://facebook.github.io/graphql/.
 
-GraphQL is a modern replacement of the almost obsolete REST approach to present API. It's been almost 16 years since the REST idea was found in 2000 by Roy Fielding. With all credit to everything we accomplished using REST it's time to change for something better.
-GraphQL advanced in many ways and has fundamental improvements over the old good REST:
+GraphQL is a query-language that operates over a single HTTP endpoint. Pioneered by Faceebook, GraphQL has focus on making the smallest possible over-the-wire responses to any request. GraphQL ignores many of the concepts that have made "REST over HTTP" so popular since 2000, creating its own conventions to solve many problems trying to make APIs flexible enough for a multitude of different clients, whilst keeping them performant.
 
- - self-checks embedded on the ground level of your backend architecture
- - reusable API for different client versions and devices, i.e. no more need in maintaining "/v1" and "/v2"
- - a complete new level of distinguishing of the backend and frontend logic
+[GraphQL differs in many ways to REST](https://philsturgeon.uk/api/2017/01/24/graphql-vs-rest-overview/
+) and has fundamental improvements for APIs with requirements that have outgrown it:
+
+ - the tempation to version in the URL is gone, forcing evolution as a tactic
+ - its possible to track which fields are required by various clients, expediating the deprecation aspect of evolution
+ - bulk requests and responses to avoiding waiting for multiple HTTP handshakes
  - easily generated documentation and incredibly intuitive way to explore created API
- - once your architecture is complete – most client-based changes does not require backend modifications
+ - clients will be much less likely to require backend changes
 
-It could be hard to believe but give it a try and you'll be rewarded with much better architecture and so much easier to support code.
 
 > Current package is and will be trying to be kept up to date with the latest revision of the official GraphQL Specification which is now of April 2016.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This is a pure PHP realization of the GraphQL protocol based on the working draft of the official GraphQL Specification located on http://facebook.github.io/graphql/.
 
-GraphQL is a query-language that operates over a single HTTP endpoint. Pioneered by Faceebook, GraphQL has focus on making the smallest possible over-the-wire responses to any request. GraphQL ignores many of the concepts that have made "REST over HTTP" so popular since 2000, creating its own conventions to solve many problems trying to make APIs flexible enough for a multitude of different clients, whilst keeping them performant.
+GraphQL is a query-language that operates over a single HTTP endpoint. Pioneered by Facebook, GraphQL has focus on making the smallest possible over-the-wire responses to any request. GraphQL ignores many of the concepts that have made "REST over HTTP" so popular since 2000, creating its own conventions to solve many problems trying to make APIs flexible enough for a multitude of different clients, whilst keeping them performant.
 
 [GraphQL differs in many ways to REST](https://philsturgeon.uk/api/2017/01/24/graphql-vs-rest-overview/
 ) and has fundamental improvements for APIs with requirements that have outgrown it:


### PR DESCRIPTION
Hey there! I'm making this PR with the best of intentions, but I'm sure it'll be taken as aggressive. Not the goal. 

Recently I've been [trying to explain to people](https://philsturgeon.uk/api/2017/01/24/graphql-vs-rest-overview/) the differences between GraphQL and REST and debunk some of the "GraphQL is magically better" stuff going around. Your introduction is furthering the issue. 

Generally, GraphQL and REST are just different, and pretending that one is better is going to confuse people.

> self-checks embedded on the ground level of your backend architecture

What does this mean

> reusable API for different client versions and devices, i.e. no more need in maintaining "/v1" and "/v2"

This was never recommended in REST, in fact the opposite was recommended. [Evolvability is king for both](https://www.mnot.net/blog/2012/12/04/api-evolution).

> easily generated documentation and incredibly intuitive way to explore created API

Yeah! Love it, but their schemas are based on concepts like JSON Schema, JSON LD, OpenAPI, etc, and exploring the API is what HATEOAS provides, which is a REST concept. 

> once your architecture is complete – most client-based changes does not require backend modifications

👍

I had a go at making it a bit more accurate for you, I hope you like it!