### PR TITLE
Have the DateTimeType description be dynamic to the format used

### DIFF
--- a/src/Type/Scalar/DateTimeType.php
+++ b/src/Type/Scalar/DateTimeType.php
@@ -69,7 +69,7 @@ class DateTimeType extends AbstractScalarType
 
     public function getDescription()
     {
-        return 'Representation of date and time in "Y-m-d H:i:s" format';
+        return "Representation of date and time in \"{$this->format}\" format";
     }
 
 }


### PR DESCRIPTION
Currently its misleading to the api user on what datetime format is expected when its different from the default