### PR TITLE
Add ResolveInfo as a second, hidden argument to resolveType call for …

### DIFF
--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -452,7 +452,12 @@ class Processor
 
         /** @var AbstractUnionType $type */
         $type         = $field->getType()->getNullableType();
-        $resolvedType = $type->resolveType($resolvedValue);
+        $resolveInfo = new ResolveInfo(
+            $field,
+            $ast instanceof AstQuery ? $ast->getFields() : [],
+            $this->executionContext
+        );
+        $resolvedType = $type->resolveType($resolvedValue, $resolveInfo);
 
         if (!$resolvedType) {
             throw new ResolveException('Resolving function must return type');


### PR DESCRIPTION
Interfaces and Unions rely on the `resolveType` method to differentiate between different types. As this method must be implemented in the interface class, it is impossible to define generic interfaces other application modules extend. The interface class must know all concrete implementations (which kind of contradicts the idea of interfaces). 

While this behavior cannot be changed in the current version, this PR provides access to the Execution Context / Container as a optional second argument to the `resolveType`. This way concrete type resolution can be delegated to another service:

```php
class AssignmentInterfaceType extends AbstractInterfaceType
{
    /**
     * {@inheritdoc}
     */
    public function resolveType($object, ResolveInfo $resolveInfo = null)
    {
        $typeResolver = $resolveInfo->getContainer()->get(MyTypeResolver::class);

        return $typeResolver->resolveInterfaceType($object);
    }
}
```
In this example the decision which concrete type to return is simply delegated to another service (possibly created by DI ...), leaving the Interface itself unaware of concrete implementations. 

 To keep the change backwards compatible, the signature of `resolveType` is not changed on the `AbstractInterfaceType`. In order to access the additional parameter while keeping the function signature the same, it must be specified as an optional parameter.