### PR TITLE
Explicitly return Boolean type name

### DIFF
--- a/src/Type/Scalar/BooleanType.php
+++ b/src/Type/Scalar/BooleanType.php
@@ -11,6 +11,10 @@ namespace Youshido\GraphQL\Type\Scalar;
 
 class BooleanType extends AbstractScalarType
 {
+    public function getName()
+    {
+        return 'Boolean';
+    }
 
     public function serialize($value)
     {


### PR DESCRIPTION
By default `BooleanType` has the name of 'Boolean', that works for most cases. But in the edge cases it's better to explicitly return the name of 'Boolean', and keep consistent with other scalar types like 'StringType', 'IntType'.

For example some dependent library will override it:

```php
class GraphQLBoolean extends BooleanType {

}
```
The `GraphQLBoolean` type ends up getting an odd name of 'GraphQLBoo'