### PR TITLE
Improve validation error message bubbling.

### DIFF
--- a/Tests/Library/Type/InputObjectTypeTest.php
+++ b/Tests/Library/Type/InputObjectTypeTest.php
@@ -87,7 +87,7 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
             [
                 'data'   => ['createList' => null],
                 'errors' => [[
-                    'message'   => 'Not valid type for argument "posts" in query "createList": Not valid type for field "title" in input type "PostInputType": Field "" must not be NULL',
+                    'message'   => 'Not valid type for argument "posts" in query "createList": Not valid type for field "title" in input type "PostInputType": Field must not be NULL',
                     'locations' => [
                         [
                             'line'   => 1,
@@ -185,7 +185,7 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'data'   => ['createList' => null],
             'errors' => [[
-                'message'   => 'Not valid type for argument "topArgument" in query "createList": Not valid type for field "postObject" in input type "topArgument": Not valid type for field "title" in input type "postObject": Field "" must not be NULL',
+                'message'   => 'Not valid type for argument "topArgument" in query "createList": Not valid type for field "postObject" in input type "topArgument": Not valid type for field "title" in input type "postObject": Field must not be NULL',
                 'locations' => [
                     [
                         'line'   => 1,

--- a/Tests/Library/Type/InputObjectTypeTest.php
+++ b/Tests/Library/Type/InputObjectTypeTest.php
@@ -87,7 +87,7 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
             [
                 'data'   => ['createList' => null],
                 'errors' => [[
-                    'message'   => 'Not valid type for argument "posts" in query "createList"',
+                    'message'   => 'Not valid type for argument "posts" in query "createList": (no details available)',
                     'locations' => [
                         [
                             'line'   => 1,
@@ -185,7 +185,7 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'data'   => ['createList' => null],
             'errors' => [[
-                'message'   => 'Not valid type for argument "topArgument" in query "createList"',
+                'message'   => 'Not valid type for argument "topArgument" in query "createList": Not valid type for field "postObject" in input type "topArgument": (no details available)',
                 'locations' => [
                     [
                         'line'   => 1,
@@ -284,7 +284,7 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
             [
                 'data' => ['createPost' => null],
                 'errors' => [[
-                    'message' => 'userId is required on InputPostType',
+                    'message' => 'Not valid type for argument "object" in query "createPost": userId is required on InputPostType',
                     'locations' => [
                         ['line' => 1, 'column' => 23]
                     ]

--- a/Tests/Library/Type/InputObjectTypeTest.php
+++ b/Tests/Library/Type/InputObjectTypeTest.php
@@ -87,7 +87,7 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
             [
                 'data'   => ['createList' => null],
                 'errors' => [[
-                    'message'   => 'Not valid type for argument "posts" in query "createList": (no details available)',
+                    'message'   => 'Not valid type for argument "posts" in query "createList": Not valid type for field "title" in input type "PostInputType": Field "" must not be NULL',
                     'locations' => [
                         [
                             'line'   => 1,
@@ -185,7 +185,7 @@ class InputObjectTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'data'   => ['createList' => null],
             'errors' => [[
-                'message'   => 'Not valid type for argument "topArgument" in query "createList": Not valid type for field "postObject" in input type "topArgument": (no details available)',
+                'message'   => 'Not valid type for argument "topArgument" in query "createList": Not valid type for field "postObject" in input type "topArgument": Not valid type for field "title" in input type "postObject": Field "" must not be NULL',
                 'locations' => [
                     [
                         'line'   => 1,

--- a/Tests/Schema/NonNullableTest.php
+++ b/Tests/Schema/NonNullableTest.php
@@ -127,7 +127,7 @@ class NonNullableTest extends \PHPUnit_Framework_TestCase
                     ],
                     'errors' => [
                         [
-                            'message' => 'Not valid type for argument "ids" in query "nonNullArgument2"',
+                            'message' => 'Not valid type for argument "ids" in query "nonNullArgument2": (no details available)',
                             'locations' => [['line' => 1, 'column' => 25]]
                         ]
                     ]

--- a/Tests/Schema/NonNullableTest.php
+++ b/Tests/Schema/NonNullableTest.php
@@ -127,7 +127,7 @@ class NonNullableTest extends \PHPUnit_Framework_TestCase
                     ],
                     'errors' => [
                         [
-                            'message' => 'Not valid type for argument "ids" in query "nonNullArgument2": (no details available)',
+                            'message' => 'Not valid type for argument "ids" in query "nonNullArgument2": Field "" must not be NULL',
                             'locations' => [['line' => 1, 'column' => 25]]
                         ]
                     ]
@@ -189,7 +189,7 @@ class NonNullableTest extends \PHPUnit_Framework_TestCase
                     ],
                     'errors' => [
                         [
-                            'message' => 'Not valid resolved type for field "nonNullListOfNpnNull"'
+                            'message' => 'Not valid resolved type for field "nonNullListOfNpnNull": Field "" must not be NULL'
                         ]
                     ]
                 ]

--- a/Tests/Schema/NonNullableTest.php
+++ b/Tests/Schema/NonNullableTest.php
@@ -127,7 +127,7 @@ class NonNullableTest extends \PHPUnit_Framework_TestCase
                     ],
                     'errors' => [
                         [
-                            'message' => 'Not valid type for argument "ids" in query "nonNullArgument2": Field "" must not be NULL',
+                            'message' => 'Not valid type for argument "ids" in query "nonNullArgument2": Field must not be NULL',
                             'locations' => [['line' => 1, 'column' => 25]]
                         ]
                     ]
@@ -189,7 +189,7 @@ class NonNullableTest extends \PHPUnit_Framework_TestCase
                     ],
                     'errors' => [
                         [
-                            'message' => 'Not valid resolved type for field "nonNullListOfNpnNull": Field "" must not be NULL'
+                            'message' => 'Not valid resolved type for field "nonNullListOfNpnNull": Field must not be NULL'
                         ]
                     ]
                 ]

--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -414,7 +414,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'data'   => ['alias' => null],
             'errors' => [[
-                'message'   => 'Not valid type for argument "argument1" in query "test": (no details available)',
+                'message'   => 'Not valid type for argument "argument1" in query "test": Value must be one of the allowed ones: VALUE1 (val1), VALUE2 (val2)',
                 'locations' => [
                     [
                         'line'   => 1,
@@ -509,14 +509,14 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->processPayload('{ listEnumQuery }');
         $this->assertEquals([
             'data'   => ['listEnumQuery' => [null]],
-            'errors' => [['message' => 'Not valid resolved type for field "listEnumQuery": (no details available)']]
+            'errors' => [['message' => 'Not valid resolved type for field "listEnumQuery": Value must be one of the allowed ones: FINISHED (1), NEW (0)']]
         ], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 
         $processor->processPayload('{ invalidEnumQuery }');
         $this->assertEquals([
             'data'   => ['invalidEnumQuery' => null],
-            'errors' => [['message' => 'Not valid resolved type for field "invalidEnumQuery": (no details available)']],
+            'errors' => [['message' => 'Not valid resolved type for field "invalidEnumQuery": Value must be one of the allowed ones: FINISHED (1), NEW (0)']],
         ], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 

--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -318,7 +318,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->getExecutionContext()->clearErrors();
 
         $processor->processPayload('{ invalidValueQuery { id } }');
-        $this->assertEquals(['errors' => [['message' => 'Not valid resolved type for field "invalidValueQuery"']], 'data' => ['invalidValueQuery' => null]], $processor->getResponseData());
+        $this->assertEquals(['errors' => [['message' => 'Not valid resolved type for field "invalidValueQuery": (no details available)']], 'data' => ['invalidValueQuery' => null]], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 
         $processor->processPayload('{ me { firstName(shorten: true), middle }}');
@@ -502,21 +502,21 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->processPayload('{ listQuery }');
         $this->assertEquals([
             'data'   => ['listQuery' => null],
-            'errors' => [['message' => 'Not valid resolved type for field "listQuery"']]
+            'errors' => [['message' => 'Not valid resolved type for field "listQuery": The value is not an iterable.']]
         ], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 
         $processor->processPayload('{ listEnumQuery }');
         $this->assertEquals([
             'data'   => ['listEnumQuery' => [null]],
-            'errors' => [['message' => 'Not valid resolved type for field "listEnumQuery"']]
+            'errors' => [['message' => 'Not valid resolved type for field "listEnumQuery": (no details available)']]
         ], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 
         $processor->processPayload('{ invalidEnumQuery }');
         $this->assertEquals([
             'data'   => ['invalidEnumQuery' => null],
-            'errors' => [['message' => 'Not valid resolved type for field "invalidEnumQuery"']],
+            'errors' => [['message' => 'Not valid resolved type for field "invalidEnumQuery": (no details available)']],
         ], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 
@@ -533,7 +533,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $processor->processPayload('{ invalidNonNullInsideQuery }');
         $this->assertEquals([
             'data'   => ['invalidNonNullInsideQuery' => null],
-            'errors' => [['message' => 'Not valid resolved type for field "invalidNonNullInsideQuery"']],
+            'errors' => [['message' => 'Not valid resolved type for field "invalidNonNullInsideQuery": (no details available)']],
         ], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 

--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -414,7 +414,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'data'   => ['alias' => null],
             'errors' => [[
-                'message'   => 'Not valid type for argument "argument1" in query "test"',
+                'message'   => 'Not valid type for argument "argument1" in query "test": (no details available)',
                 'locations' => [
                     [
                         'line'   => 1,

--- a/Tests/Schema/ProcessorTest.php
+++ b/Tests/Schema/ProcessorTest.php
@@ -265,7 +265,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
         $processor->processPayload('mutation { invalidMutation }');
         $this->assertEquals(['errors' => [[
-            'message'   => 'Field "invalidMutation" not found in type "RootSchemaMutation"',
+            'message'   => 'Field "invalidMutation" not found in type "RootSchemaMutation". Available fields are: "increaseCounter", "invalidResolveTypeMutation", "interfacedMutation"',
             'locations' => [
                 [
                     'line'   => 1,
@@ -307,7 +307,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
         $processor->processPayload('{ invalidQuery }');
         $this->assertEquals(['errors' => [[
-            'message'   => 'Field "invalidQuery" not found in type "RootQuery"',
+            'message'   => 'Field "invalidQuery" not found in type "RootQuery". Available fields are: "me", "randomUser", "invalidValueQuery", "labels", "__schema", "__type"',
             'locations' => [
                 [
                     'line'   => 1,
@@ -325,7 +325,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals([
             'data'   => ['me' => null],
             'errors' => [[
-                'message'   => 'Field "middle" not found in type "User"',
+                'message'   => 'Field "middle" not found in type "User". Available fields are: "firstName", "id_alias", "lastName", "code"',
                 'locations' => [
                     [
                         'line'   => 1,
@@ -624,7 +624,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
             ],
             'errors' => [
                 [
-                    'message'   => 'Field "name" not found in type "Object1"',
+                    'message'   => 'Field "name" not found in type "Object1". Available fields are: "id"',
                     'locations' => [
                         [
                             'line'   => 1,
@@ -775,7 +775,7 @@ class ProcessorTest extends \PHPUnit_Framework_TestCase
 
         // don't let complexity reducer affect query errors
         $processor->processPayload('{ me { badfield } }');
-        $this->assertArraySubset(['errors' => [['message' => 'Field "badfield" not found in type "User"']]], $processor->getResponseData());
+        $this->assertArraySubset(['errors' => [['message' => 'Field "badfield" not found in type "User". Available fields are: "firstName", "lastName", "code", "likes"']]], $processor->getResponseData());
         $processor->getExecutionContext()->clearErrors();
 
         foreach (range(1, 5) as $cost_multiplier) {

--- a/Tests/Schema/VariablesTest.php
+++ b/Tests/Schema/VariablesTest.php
@@ -50,7 +50,7 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals(['data' => ['list' => null], 'errors' => [
             [
-                'message'   => 'Not valid type for argument "ids" in query "list"',
+                'message'   => 'Not valid type for argument "ids" in query "list": (no details available)',
                 'locations' => [
                     ['line' => 1, 'column' => 35],
                 ],

--- a/Tests/Schema/VariablesTest.php
+++ b/Tests/Schema/VariablesTest.php
@@ -50,7 +50,7 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals(['data' => ['list' => null], 'errors' => [
             [
-                'message'   => 'Not valid type for argument "ids" in query "list": (no details available)',
+                'message'   => 'Not valid type for argument "ids" in query "list": Field "" must not be NULL',
                 'locations' => [
                     ['line' => 1, 'column' => 35],
                 ],

--- a/Tests/Schema/VariablesTest.php
+++ b/Tests/Schema/VariablesTest.php
@@ -50,7 +50,7 @@ class VariablesTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals(['data' => ['list' => null], 'errors' => [
             [
-                'message'   => 'Not valid type for argument "ids" in query "list": Field "" must not be NULL',
+                'message'   => 'Not valid type for argument "ids" in query "list": Field must not be NULL',
                 'locations' => [
                     ['line' => 1, 'column' => 35],
                 ],

--- a/src/Type/Enum/AbstractEnumType.php
+++ b/src/Type/Enum/AbstractEnumType.php
@@ -51,10 +51,15 @@ abstract class AbstractEnumType extends AbstractType
         if (is_null($value)) return true;
         foreach ($this->getConfig()->get('values') as $item) {
             if ($value === $item['name'] || $value === $item['value']) {
+                $this->lastError = null;
                 return true;
             }
         }
 
+        $allowedValues = array_map(function (array $value) {
+            return sprintf('%s (%s)', $value['name'], $value['value']);
+        }, $this->getConfig()->get('values'));
+        $this->lastError = sprintf('Value must be one of the allowed ones: %s', implode(', ', $allowedValues));
         return false;
     }
 

--- a/src/Type/InputObject/AbstractInputObjectType.php
+++ b/src/Type/InputObject/AbstractInputObjectType.php
@@ -70,7 +70,15 @@ abstract class AbstractInputObjectType extends AbstractType
         });
 
         foreach ($value as $valueKey => $valueItem) {
-            if (!$typeConfig->hasField($valueKey) || !$typeConfig->getField($valueKey)->getType()->isValidValue($valueItem)) {
+            if (!$typeConfig->hasField($valueKey)) {
+                $this->lastError = sprintf('Field "%s" does not exist for input type "%s"', $valueKey, $this->getName());
+                return false;
+            }
+
+            $field = $typeConfig->getField($valueKey);
+            if (!$field->getType()->isValidValue($valueItem)) {
+                $error = $field->getType()->getLastError() ?: '(no details available)';
+                $this->lastError = sprintf('Not valid type for field "%s" in input type "%s": %s', $field->getName(), $this->getName(), $error);
                 return false;
             }
 

--- a/src/Type/InputObject/AbstractInputObjectType.php
+++ b/src/Type/InputObject/AbstractInputObjectType.php
@@ -71,7 +71,7 @@ abstract class AbstractInputObjectType extends AbstractType
 
         foreach ($value as $valueKey => $valueItem) {
             if (!$typeConfig->hasField($valueKey)) {
-                $this->lastError = sprintf('Field "%s" does not exist for input type "%s"', $valueKey, $this->getName());
+                // Schema validation will generate the error message for us.
                 return false;
             }
 

--- a/src/Type/ListType/AbstractListType.php
+++ b/src/Type/ListType/AbstractListType.php
@@ -32,20 +32,23 @@ abstract class AbstractListType extends AbstractObjectType implements CompositeT
 
     public function isValidValue($value)
     {
-        $isValid  = is_null($value) || is_array($value) || ($value instanceof \Traversable);
+        if (!is_null($value) && !is_array($value) && !($value instanceof \Traversable)) {
+          $this->lastError = 'The value is not an iterable.';
+          return false;
+        }
+        $this->lastError = null;
+
         $itemType = $this->config->get('itemType');
 
-        if ($isValid && $value && $itemType->isInputType()) {
+        if ($value && $itemType->isInputType()) {
             foreach ($value as $item) {
-                $isValid = $itemType->isValidValue($item);
-
-                if (!$isValid) {
-                    break;
+                if (!$itemType->isValidValue($item)) {
+                  return false;
                 }
             }
         }
 
-        return $isValid;
+        return true;
     }
 
     /**
@@ -82,6 +85,11 @@ abstract class AbstractListType extends AbstractObjectType implements CompositeT
         }
 
         return $value;
+    }
+
+    public function getLastError()
+    {
+        return $this->lastError ?: $this->config->get('itemType')->getLastError();
     }
 
 }

--- a/src/Type/NonNullType.php
+++ b/src/Type/NonNullType.php
@@ -59,7 +59,7 @@ final class NonNullType extends AbstractType implements CompositeTypeInterface
             return false;
         }
         else {
-          $this->lastError = null;
+            $this->lastError = null;
         }
 
         return $this->getNullableType()->isValidValue($value);

--- a/src/Type/NonNullType.php
+++ b/src/Type/NonNullType.php
@@ -55,7 +55,11 @@ final class NonNullType extends AbstractType implements CompositeTypeInterface
     public function isValidValue($value)
     {
         if ($value === null) {
+            $this->lastError = sprintf('Field "%s" must not be NULL', $this->getName());
             return false;
+        }
+        else {
+          $this->lastError = null;
         }
 
         return $this->getNullableType()->isValidValue($value);
@@ -89,6 +93,11 @@ final class NonNullType extends AbstractType implements CompositeTypeInterface
     public function parseValue($value)
     {
         return $this->getNullableType()->parseValue($value);
+    }
+
+    public function getLastError()
+    {
+        return $this->lastError ?: $this->getNullableType()->getLastError();
     }
 
 

--- a/src/Type/NonNullType.php
+++ b/src/Type/NonNullType.php
@@ -55,7 +55,7 @@ final class NonNullType extends AbstractType implements CompositeTypeInterface
     public function isValidValue($value)
     {
         if ($value === null) {
-            $this->lastError = sprintf('Field "%s" must not be NULL', $this->getName());
+            $this->lastError = 'Field must not be NULL';
             return false;
         }
         else {

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -27,10 +27,10 @@ class ResolveValidator implements ResolveValidatorInterface
     {
         /** @var AbstractObjectType $objectType */
         if (!(TypeService::isObjectType($objectType) || TypeService::isInputObjectType($objectType)) || !$objectType->hasField($ast->getName())) {
-          $availableFieldNames = implode(', ', array_map(function (FieldInterface $field): string {
-            return sprintf('"%s"', $field->getName());
-          }, $objectType->getFields()));
-          throw new ResolveException(sprintf('Field "%s" not found in type "%s". Available fields are: %s', $ast->getName(), $objectType->getNamedType()->getName(), $availableFieldNames), $ast->getLocation());
+            $availableFieldNames = implode(', ', array_map(function (FieldInterface $field): string {
+              return sprintf('"%s"', $field->getName());
+            }, $objectType->getFields()));
+            throw new ResolveException(sprintf('Field "%s" not found in type "%s". Available fields are: %s', $ast->getName(), $objectType->getNamedType()->getName(), $availableFieldNames), $ast->getLocation());
         }
     }
 
@@ -54,8 +54,8 @@ class ResolveValidator implements ResolveValidatorInterface
                 case TypeMap::KIND_INPUT_OBJECT:
                 case TypeMap::KIND_LIST:
                     if (!$argument->getType()->isValidValue($astArgument->getValue())) {
-                      $error = $argument->getType()->getLastError() ?: '(no details available)';
-                      throw new ResolveException(sprintf('Not valid type for argument "%s" in query "%s": %s', $astArgument->getName(), $field->getName(), $error), $astArgument->getLocation());
+                        $error = $argument->getType()->getLastError() ?: '(no details available)';
+                        throw new ResolveException(sprintf('Not valid type for argument "%s" in query "%s": %s', $astArgument->getName(), $field->getName(), $error), $astArgument->getLocation());
                     }
 
                     break;

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -27,7 +27,10 @@ class ResolveValidator implements ResolveValidatorInterface
     {
         /** @var AbstractObjectType $objectType */
         if (!(TypeService::isObjectType($objectType) || TypeService::isInputObjectType($objectType)) || !$objectType->hasField($ast->getName())) {
-            throw new ResolveException(sprintf('Field "%s" not found in type "%s"', $ast->getName(), $objectType->getNamedType()->getName()), $ast->getLocation());
+          $availableFieldNames = implode(', ', array_map(function (FieldInterface $field): string {
+            return sprintf('"%s"', $field->getName());
+          }, $objectType->getFields()));
+          throw new ResolveException(sprintf('Field "%s" not found in type "%s". Available fields are: %s', $ast->getName(), $objectType->getNamedType()->getName(), $availableFieldNames), $ast->getLocation());
         }
     }
 

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -51,8 +51,8 @@ class ResolveValidator implements ResolveValidatorInterface
                 case TypeMap::KIND_INPUT_OBJECT:
                 case TypeMap::KIND_LIST:
                     if (!$argument->getType()->isValidValue($astArgument->getValue())) {
-                        $error = $argument->getType()->getLastError();
-                        throw new ResolveException($error ? $error : sprintf('Not valid type for argument "%s" in query "%s"', $astArgument->getName(), $field->getName()), $astArgument->getLocation());
+                      $error = $argument->getType()->getLastError() ?: '(no details available)';
+                      throw new ResolveException(sprintf('Not valid type for argument "%s" in query "%s": %s', $astArgument->getName(), $field->getName(), $error), $astArgument->getLocation());
                     }
 
                     break;

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -27,7 +27,7 @@ class ResolveValidator implements ResolveValidatorInterface
     {
         /** @var AbstractObjectType $objectType */
         if (!(TypeService::isObjectType($objectType) || TypeService::isInputObjectType($objectType)) || !$objectType->hasField($ast->getName())) {
-            $availableFieldNames = implode(', ', array_map(function (FieldInterface $field): string {
+            $availableFieldNames = implode(', ', array_map(function (FieldInterface $field) {
               return sprintf('"%s"', $field->getName());
             }, $objectType->getFields()));
             throw new ResolveException(sprintf('Field "%s" not found in type "%s". Available fields are: %s', $ast->getName(), $objectType->getNamedType()->getName(), $availableFieldNames), $ast->getLocation());

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -81,8 +81,11 @@ class ResolveValidator implements ResolveValidatorInterface
             throw new ResolveException(sprintf('Cannot return null for non-nullable field "%s"', $field->getName()));
         }
 
-        if (!$field->getType()->getNullableType()->isValidValue($resolvedValue)) {
-            throw new ResolveException(sprintf('Not valid resolved type for field "%s"', $field->getName()));
+        $nullableFieldType = $field->getType()->getNullableType();
+        if (!$nullableFieldType->isValidValue($resolvedValue)) {
+            $error = $nullableFieldType->getLastError() ?: '(no details available)';
+            throw new ResolveException(sprintf('Not valid resolved type for field "%s": %s', $field->getName(),
+                $error));
         }
     }
 


### PR DESCRIPTION
When objects are validated, they just check if their contained field values are valid, but are not able attach instructions to the validation result. This PR intensifies the usage of the 'last error' feature to introduce a limited form of error message bubbling. By appending nested errors, we get some more useful information about the location of the invalid data as well. You can see this in action in some of the tests, where the 'nested' error messages are separated by colons in the resulting error message. Before this, the library would tell you your input object would be invalid. Now it tells you that's because property X is NULL and mustn't be, greatly reducing debugging time.

I couldn't find any information on code style in the project README or in the Travis CI configuration. Please let me know how to handle this :)