### PR TITLE
Fix code that would run into arbitrary date comparison failures, partly caused by backwards-incompatible changes in PHP 7.1.

### DIFF
--- a/Tests/DataProvider/TestScalarDataProvider.php
+++ b/Tests/DataProvider/TestScalarDataProvider.php
@@ -103,33 +103,37 @@ class TestScalarDataProvider
 
     public static function getDatetimeTestData()
     {
+        $time = time();
         return [
             [null, null, true],
-            [new \DateTime('now'), date('Y-m-d H:i:s'), true],
+            [(new \DateTime())->setTimestamp($time), date('Y-m-d H:i:s', $time), true],
         ];
     }
 
     public static function getDatetimetzTestData()
     {
+        $time = time();
         return [
             [null, null, true],
-            [new \DateTime('now'), date('r'), true],
+            [(new \DateTime())->setTimestamp($time), date('r', $time), true],
         ];
     }
 
     public static function getDateTestData()
     {
+        $time = time();
         return [
             [null, null, true],
-            [new \DateTime('now'), date('Y-m-d'), true],
+            [(new \DateTime())->setTimestamp($time), date('Y-m-d', $time), true],
         ];
     }
 
 
     public static function getTimestampTestData()
     {
+        $time = time();
         return [
-            [new \DateTime('now'), time(), true],
+            [(new \DateTime())->setTimestamp($time), $time, true],
             [null, null, true],
         ];
     }


### PR DESCRIPTION
One of the test fixtures was a little unstable already, because it would compare individually instantiated times and assume they'd be identical (which would fail if the test was run exactly when the clock changed). PHP 7.1 also introduced a [backwards-incompatible change](http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds) to `\DateTime('now')`, which these same fixtures uses, exacerbating the problem. This PR fixes both issues.