### PR TITLE
Add a type/field lookup cache for improved performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ phpunit.xml
 vendor/
 data/schema.graphql
 composer.lock
+.idea

--- a/src/Execution/Context/ExecutionContext.php
+++ b/src/Execution/Context/ExecutionContext.php
@@ -11,9 +11,11 @@ namespace Youshido\GraphQL\Execution\Context;
 
 use Youshido\GraphQL\Execution\Container\ContainerInterface;
 use Youshido\GraphQL\Execution\Request;
+use Youshido\GraphQL\Field\Field;
 use Youshido\GraphQL\Introspection\Field\SchemaField;
 use Youshido\GraphQL\Introspection\Field\TypeDefinitionField;
 use Youshido\GraphQL\Schema\AbstractSchema;
+use Youshido\GraphQL\Type\Object\AbstractObjectType;
 use Youshido\GraphQL\Validator\ErrorContainer\ErrorContainerTrait;
 use Youshido\GraphQL\Validator\SchemaValidator\SchemaValidator;
 
@@ -31,6 +33,9 @@ class ExecutionContext implements ExecutionContextInterface
     /** @var ContainerInterface */
     private $container;
 
+    /** @var array */
+    private $typeFieldLookupTable;
+
     /**
      * ExecutionContext constructor.
      *
@@ -42,6 +47,29 @@ class ExecutionContext implements ExecutionContextInterface
         $this->validateSchema();
 
         $this->introduceIntrospectionFields();
+
+        $this->typeFieldLookupTable = [];
+    }
+
+    /**
+     * @param AbstractObjectType $type
+     * @param string             $fieldName
+     * 
+     * @return Field
+     */
+    public function getField(AbstractObjectType $type, $fieldName)
+    {
+        $typeName = $type->getName();
+
+        if (!array_key_exists($typeName, $this->typeFieldLookupTable)) {
+            $this->typeFieldLookupTable[$typeName] = [];
+        }
+
+        if (!array_key_exists($fieldName, $this->typeFieldLookupTable[$typeName])) {
+            $this->typeFieldLookupTable[$typeName][$fieldName] = $type->getField($fieldName);
+        }
+
+        return $this->typeFieldLookupTable[$typeName][$fieldName];
     }
 
     protected function validateSchema()

--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -167,7 +167,7 @@ class Processor
 
             $this->resolveValidator->assetTypeHasField($nonNullType, $ast);
 
-            $targetField = $nonNullType->getField($ast->getName());
+            $targetField = $this->executionContext->getField($nonNullType, $ast->getName());
 
             $this->prepareAstArguments($targetField, $ast, $this->executionContext->getRequest());
             $this->resolveValidator->assertValidArguments($targetField, $ast, $this->executionContext->getRequest());

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -9,6 +9,7 @@ namespace Youshido\GraphQL\Validator\ResolveValidator;
 
 
 use Youshido\GraphQL\Exception\ResolveException;
+use Youshido\GraphQL\Execution\Context\ExecutionContext;
 use Youshido\GraphQL\Execution\Request;
 use Youshido\GraphQL\Field\FieldInterface;
 use Youshido\GraphQL\Field\InputField;
@@ -22,6 +23,21 @@ use Youshido\GraphQL\Type\Union\AbstractUnionType;
 
 class ResolveValidator implements ResolveValidatorInterface
 {
+
+    /** @var ExecutionContext */
+    private $executionContext;
+
+
+    /**
+     * ResolveValidator constructor.
+     *
+     * @param ExecutionContext $executionContext
+     */
+    public function __construct(ExecutionContext $executionContext)
+    {
+        $this->executionContext = $executionContext;
+    }
+    
     public function assetTypeHasField(AbstractType $objectType, AstFieldInterface $ast)
     {
         /** @var AbstractObjectType $objectType */

--- a/src/Validator/ResolveValidator/ResolveValidator.php
+++ b/src/Validator/ResolveValidator/ResolveValidator.php
@@ -41,6 +41,10 @@ class ResolveValidator implements ResolveValidatorInterface
     public function assetTypeHasField(AbstractType $objectType, AstFieldInterface $ast)
     {
         /** @var AbstractObjectType $objectType */
+        if ($this->executionContext->getField($objectType, $ast->getName()) !== null) {
+            return;
+        }
+        
         if (!(TypeService::isObjectType($objectType) || TypeService::isInputObjectType($objectType)) || !$objectType->hasField($ast->getName())) {
             $availableFieldNames = implode(', ', array_map(function (FieldInterface $field) {
                 return sprintf('"%s"', $field->getName());


### PR DESCRIPTION
In a project I'm working on we're caching the `Processor` instance to speed up the bootstrapping time of each GraphQL request. Since the `Processor` has the `Schema` as a member this alone speeds up execution time somewhat since the schema doesn't have to parsed on every request.

During further investigation I noticed that a lot of processing time is spent on resolving things. Specifically, each time an object is resolved, the `Type` has to be built and its `Field`s need to be parsed and validated. This process is not slow per se, but `getFields()` (which calls `getConfig()`, which calls `build()`) ends up being called a lot, which increases execution time in the long run.

Since `Type`s and `Field`s don't magically change between requests (and even between deployments), I figured we can bypass some of this by using a lookup table. Since the execution context is a member of `Processor`, caching the processor also implies caching the execution context. The `ResolveValidator` also takes in the execution context through its constructor, so I figured the logical place to put the lookup table is there.

This pull request adds that lookup table. Profiling results from a typical request look promising:

```
$ ls -lh --sort=time cachegrind*
-rw-r--r-- 1 negge negge 4.7M Jul  7 11:20 cachegrind.out.17345.0a38ea
-rw-r--r-- 1 negge negge 5.3M Jul  7 11:05 cachegrind.out.17346
-rw-r--r-- 1 negge negge 6.1M Jul  7 10:24 cachegrind.out.17345.0890c5
```

The oldest file is without this patch. The middle one is from when the lookup table is only used in `Processor::resolveField()`. The third and final file is from when the lookup table is also used by `ResolveValidator`.