### PR TITLE
Provide failing test for querying multiple root fields

### DIFF
--- a/Tests/StarWars/StarWarsTest.php
+++ b/Tests/StarWars/StarWarsTest.php
@@ -58,6 +58,30 @@ class StarWarsTest extends \PHPUnit_Framework_TestCase
                 ]
             ]
         ]);
+    }    
+	
+	public function testMultipleRootFields()
+    {
+        $processor = new Processor(new StarWarsSchema());
+
+        $processor->processPayload(
+            'query(){
+                q1: human(id: "1000") {
+                    name
+                }
+                q2: human(id: "1001") {
+                    name
+                }
+            }', []
+        );
+
+        $data = $processor->getResponseData();
+        $this->assertEquals($data, [
+            'data'   => [
+				'q1' => ['name' => 'Luke Skywalker'],
+				'q2' => ['name' => 'Darth Vader'],
+			],
+        ]);
     }
 
 


### PR DESCRIPTION
For current master branch, actual result of this query is:

```
{
  "errors": [
    {
      "message": "Unexpected token \"IDENTIFIER\"",
      "locations": [
        {
          "line": 5,
          "column": 18
        }
      ]
    }
  ]
}
```

For v1.4.3.4 this query works as expected.