### PR TITLE
Add missing variable for sprintf

### DIFF
--- a/src/Execution/Container/Container.php
+++ b/src/Execution/Container/Container.php
@@ -69,7 +69,7 @@ class Container implements ContainerInterface
     private function assertIdentifierSet($id)
     {
         if (!$this->has($id)) {
-            throw new \RuntimeException(sprintf('Container item "%s" was not set'));
+            throw new \RuntimeException(sprintf('Container item "%s" was not set', $id));
         }
     }
 }


### PR DESCRIPTION
Small fix, causing an exception to be thrown that sprintf has too few arguments. 