### PR TITLE
Properly handling errors during deferred resolving.

### DIFF
--- a/src/Execution/Processor.php
+++ b/src/Execution/Processor.php
@@ -93,10 +93,15 @@ class Processor
 
             // If the processor found any deferred results, resolve them now.
             if (!empty($this->data) && $this->deferredResults) {
-                while ($deferredResolver = array_shift($this->deferredResults)) {
-                    $deferredResolver->resolve();
-                }
-                $this->data = static::unpackDeferredResults($this->data);
+              try {
+                  while ($deferredResolver = array_shift($this->deferredResults)) {
+                      $deferredResolver->resolve();
+                  }
+              } catch (\Exception $e) {
+                  $this->executionContext->addError($e);
+              } finally {
+                  $this->data = static::unpackDeferredResults($this->data);
+              }
             }
 
         } catch (\Exception $e) {


### PR DESCRIPTION
When an exception is thrown during deferred resolving, the result still has to be unpacked or we end up with deferred resolvers in the result.