### PR TITLE
DateTimeXxType now accepts DateTimeImmutable inputs

### DIFF
--- a/Tests/Library/Type/ScalarTypeTest.php
+++ b/Tests/Library/Type/ScalarTypeTest.php
@@ -56,7 +56,7 @@ class ScalarTypeTest extends \PHPUnit_Framework_TestCase
     public function testDateTimeType()
     {
         $dateType = new DateTimeType('Y/m/d H:i:s');
-        $this->assertEquals('2016/05/31 12:00:00', $dateType->serialize(new \DateTime('2016-05-31 12:00pm')));
+        $this->assertEquals('2016/05/31 12:00:00', $dateType->serialize(new \DateTimeImmutable('2016-05-31 12:00pm')));
     }
 
     private function assertSerialization(AbstractScalarType $object, $input, $expected)

--- a/src/Type/Scalar/DateTimeType.php
+++ b/src/Type/Scalar/DateTimeType.php
@@ -25,7 +25,7 @@ class DateTimeType extends AbstractScalarType
 
     public function isValidValue($value)
     {
-        if ((is_object($value) && $value instanceof \DateTime) || is_null($value)) {
+        if ((is_object($value) && $value instanceof \DateTimeInterface) || is_null($value)) {
             return true;
         } else if (is_string($value)) {
             $date = $this->createFromFormat($value);
@@ -42,7 +42,7 @@ class DateTimeType extends AbstractScalarType
 
         if (is_string($value)) {
             $date = $this->createFromFormat($value);
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $date = $value;
         }
 
@@ -53,7 +53,7 @@ class DateTimeType extends AbstractScalarType
     {
         if (is_string($value)) {
             $date = $this->createFromFormat($value);
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $date = $value;
         } else {
             $date = false;

--- a/src/Type/Scalar/DateTimeTzType.php
+++ b/src/Type/Scalar/DateTimeTzType.php
@@ -18,7 +18,7 @@ class DateTimeTzType extends AbstractScalarType
     }
     public function isValidValue($value)
     {
-        if ((is_object($value) && $value instanceof \DateTime) || is_null($value)) {
+        if ((is_object($value) && $value instanceof \DateTimeInterface) || is_null($value)) {
             return true;
         } else if (is_string($value)) {
             $date = $this->createFromFormat($value);
@@ -35,7 +35,7 @@ class DateTimeTzType extends AbstractScalarType
 
         if (is_string($value)) {
             $date = $this->createFromFormat($value);
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $date = $value;
         }
 
@@ -46,7 +46,7 @@ class DateTimeTzType extends AbstractScalarType
     {
         if (is_string($value)) {
             $date = $this->createFromFormat($value);
-        } elseif ($value instanceof \DateTime) {
+        } elseif ($value instanceof \DateTimeInterface) {
             $date = $value;
         } else {
             $date = false;


### PR DESCRIPTION
The `DateTimeType` and `DateTimeTzType` currently map to the `\DateTime` PHP object.

Yet, using the `DateTimeImmutable` object (introduced in PHP 5.5) is a best practice to avoid side effects.

This PR introduces support for the `DateTimeImmutable` while keeping BC compatibility.

With this PR, a `DateTimeType` or `DateTimeTzType` can accept a `DateTimeImmutable` instance as well as a `DateTime` instance. Serialization keeps returning a `DateTime` object for compatibility reasons. It might be interesting to switch to `DateTimeImmutable` on the next major release.
