### PR TITLE
Un-escaping of string values

### DIFF
--- a/Tests/Parser/ParserTest.php
+++ b/Tests/Parser/ParserTest.php
@@ -131,7 +131,7 @@ GRAPHQL;
                 new Token(Token::TYPE_STRING, 1, 3, "\f"),
                 new Token(Token::TYPE_STRING, 1, 3, "\n"),
                 new Token(Token::TYPE_STRING, 1, 3, "\r"),     
-                new Token(Token::TYPE_STRING, 1, 3, chr(8)),         
+                new Token(Token::TYPE_STRING, 1, 3, sprintf("%c", 8)),         
                 new Token(Token::TYPE_STRING, 1, 7, html_entity_decode("&#xABCD;", ENT_QUOTES, 'UTF-8'))            
             ]
         );

--- a/Tests/Parser/ParserTest.php
+++ b/Tests/Parser/ParserTest.php
@@ -21,6 +21,17 @@ use Youshido\GraphQL\Parser\Ast\Query;
 use Youshido\GraphQL\Parser\Ast\TypedFragmentReference;
 use Youshido\GraphQL\Parser\Location;
 use Youshido\GraphQL\Parser\Parser;
+use Youshido\GraphQL\Parser\Token;
+
+class TokenizerTestingParser extends Parser {
+    public function initTokenizerForTesting($source) {
+        $this->initTokenizer($source);
+    }
+
+    public function getTokenForTesting() {
+        return $this->lookAhead;
+    }
+}
 
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
@@ -91,6 +102,40 @@ GRAPHQL;
         ]);
     }
 
+    private function tokenizeStringContents($graphQLString) {
+        $parser = new TokenizerTestingParser();
+        $parser->initTokenizerForTesting('"' . $graphQLString . '"');
+
+        return $parser->getTokenForTesting();
+    }
+
+
+    public function testEscapedStrings()
+    {
+        $this->assertEquals([
+                $this->tokenizeStringContents(""),           
+                $this->tokenizeStringContents("x"),
+                $this->tokenizeStringContents("\\\""),
+                $this->tokenizeStringContents("\\/"),   
+                $this->tokenizeStringContents("\\f"),
+                $this->tokenizeStringContents("\\n"),
+                $this->tokenizeStringContents("\\r"),         
+                $this->tokenizeStringContents("\\b"),
+                $this->tokenizeStringContents("\\uABCD")
+            ],
+            [
+                new Token(Token::TYPE_STRING, 1, 1, ""),
+                new Token(Token::TYPE_STRING, 1, 2, "x"),
+                new Token(Token::TYPE_STRING, 1, 3, '"'),
+                new Token(Token::TYPE_STRING, 1, 3, '/'),
+                new Token(Token::TYPE_STRING, 1, 3, "\f"),
+                new Token(Token::TYPE_STRING, 1, 3, "\n"),
+                new Token(Token::TYPE_STRING, 1, 3, "\r"),     
+                new Token(Token::TYPE_STRING, 1, 3, "\u{0008}"),         
+                new Token(Token::TYPE_STRING, 1, 7, "\u{ABCD}")            
+            ]
+        );
+    }
 
     /**
      * @param $query string

--- a/Tests/Parser/ParserTest.php
+++ b/Tests/Parser/ParserTest.php
@@ -131,8 +131,8 @@ GRAPHQL;
                 new Token(Token::TYPE_STRING, 1, 3, "\f"),
                 new Token(Token::TYPE_STRING, 1, 3, "\n"),
                 new Token(Token::TYPE_STRING, 1, 3, "\r"),     
-                new Token(Token::TYPE_STRING, 1, 3, "\u{0008}"),         
-                new Token(Token::TYPE_STRING, 1, 7, "\u{ABCD}")            
+                new Token(Token::TYPE_STRING, 1, 3, chr(8)),         
+                new Token(Token::TYPE_STRING, 1, 7, html_entity_decode("&#xABCD;", ENT_QUOTES, 'UTF-8'))            
             ]
         );
     }

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -320,7 +320,7 @@ class Tokenizer
                     case '/':
                         break;
                     case 'b':
-                        $ch = "\u{0008}";
+                        $ch = sprintf("%c", 8);
                         break;
                     case 'f':
                         $ch = "\f";

--- a/src/Parser/Tokenizer.php
+++ b/src/Parser/Tokenizer.php
@@ -293,20 +293,59 @@ class Tokenizer
         return $this->line;
     }
 
+    /*
+  		http://facebook.github.io/graphql/October2016/#sec-String-Value
+    */
     protected function scanString()
     {
+        $len = strlen($this->source);
         $this->pos++;
 
         $value = '';
-        while ($this->pos < strlen($this->source)) {
+        while ($this->pos < $len) {
             $ch = $this->source[$this->pos];
-            if ($ch === '"' && $this->source[$this->pos - 1] !== '\\') {
+            if ($ch === '"') {
                 $token = new Token(Token::TYPE_STRING, $this->getLine(), $this->getColumn(), $value);
                 $this->pos++;
 
                 return $token;
             }
+            
+            if($ch === '\\' && ($this->pos < ($len - 1))) {
+                $this->pos++;
+                $ch = $this->source[$this->pos];
+                switch($ch) {
+                    case '"':
+                    case '\\':
+                    case '/':
+                        break;
+                    case 'b':
+                        $ch = "\u{0008}";
+                        break;
+                    case 'f':
+                        $ch = "\f";
+                        break;
+                    case 'n':
+                        $ch = "\n";
+                        break;
+                    case 'r':
+                        $ch = "\r";
+                        break;
+                    case 'u':
+                        $codepoint = substr($this->source, $this->pos + 1, 4);
+                        if( !preg_match('/[0-9A-Fa-f]{4}/', $codepoint)) {
+                            throw $this->createException(sprintf('Invalid string unicode escape sequece "%s"', $codepoint));
+                        }
+                        $ch = html_entity_decode("&#x{$codepoint};", ENT_QUOTES, 'UTF-8');
+                        $this->pos += 4;
+                        break;
+                    default:
+                        throw $this->createException(sprintf('Unexpected string escaped character "%s"', $ch));
+                        break;
 
+                }
+            } 
+            
             $value .= $ch;
             $this->pos++;
         }


### PR DESCRIPTION
This is for https://github.com/Youshido/GraphQL/issues/195 - assuming that there's agreement that #195 is in fact a bug, then here's a proposed fix.

String values parsed from queries and mutations were not being unescaped per http://facebook.github.io/graphql/October2016/#sec-String-Value

This code updates Tokenizer.php:scanString() to returned the un-escaped version of the string.

Issues to consider in the PR:

- I think: For when variable values are passed in to the initial query / mutation via the top level 'variables' array, then those don't go through this path, instead have been unescaped by json_decode() directly, and thus are not graphQL string values.
- As written, Tokenizer.php:scanString() has issues even if it's intended to return an escaped/raw version of the string / raw text, since "\\" (a string of 1 character: backslash) will be rejected.
- I'm not 100% sure about the unit test architecture - I had to cheat a bit to introspect into the Tokenizer class. But at least there are some tests ;)
