### PR TITLE
Added missing directive locations

### DIFF
--- a/Tests/Library/Type/SchemaDirectivesListTest.php
+++ b/Tests/Library/Type/SchemaDirectivesListTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Youshido\Tests\Library\Type;
+
+use Youshido\GraphQL\Directive\Directive;
+use Youshido\GraphQL\Type\SchemaDirectivesList;
+
+class SchemaDirectivesListTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCanAddASingleDirective()
+    {
+        $directiveList = new SchemaDirectivesList();
+        $directiveList->addDirective(
+            new Directive([
+                'name' => 'testDirective'
+            ])
+        );
+        $this->assertTrue($directiveList->isDirectiveNameRegistered('testDirective'));
+    }
+
+    public function testCanAddMultipleDirectives()
+    {
+        $directiveList = new SchemaDirectivesList();
+        $directiveList->addDirectives([
+            new Directive([
+                'name' => 'testDirectiveOne'
+            ]),
+            new Directive([
+                'name' => 'testDirectiveTwo'
+            ]),
+        ]);
+        $this->assertTrue($directiveList->isDirectiveNameRegistered('testDirectiveOne'));
+        $this->assertTrue($directiveList->isDirectiveNameRegistered('testDirectiveTwo'));
+    }
+
+    public function testItThrowsExceptionWhenAddingInvalidDirectives()
+    {
+        $this->setExpectedException(\Exception::class, "addDirectives accept only array of directives");
+        $directiveList = new SchemaDirectivesList();
+        $directiveList->addDirectives("foobar");
+    }
+
+}

--- a/src/Directive/DirectiveLocation.php
+++ b/src/Directive/DirectiveLocation.php
@@ -14,8 +14,9 @@ class DirectiveLocation
     const QUERY = 'QUERY';
     const MUTATION = 'MUTATION';
     const FIELD = 'FIELD';
+    const FIELD_DEFINITION = 'FIELD_DEFINITION';
     const FRAGMENT_DEFINITION = 'FRAGMENT_DEFINITION';
     const FRAGMENT_SPREAD = 'FRAGMENT_SPREAD';
     const INLINE_FRAGMENT = 'INLINE_FRAGMENT';
-
+    const ENUM_VALUE = 'ENUM_VALUE';
 }

--- a/src/Introspection/DirectiveLocationType.php
+++ b/src/Introspection/DirectiveLocationType.php
@@ -16,9 +16,11 @@ class DirectiveLocationType extends AbstractEnumType
     const QUERY = DirectiveLocation::QUERY;
     const MUTATION = DirectiveLocation::MUTATION;
     const FIELD = DirectiveLocation::FIELD;
+    const FIELD_DEFINITION = DirectiveLocation::FIELD_DEFINITION;
     const FRAGMENT_DEFINITION = DirectiveLocation::FRAGMENT_DEFINITION;
     const FRAGMENT_SPREAD = DirectiveLocation::FRAGMENT_SPREAD;
     const INLINE_FRAGMENT = DirectiveLocation::INLINE_FRAGMENT;
+    const ENUM_VALUE = DirectiveLocation::ENUM_VALUE;
 
     public function getName()
     {
@@ -31,9 +33,11 @@ class DirectiveLocationType extends AbstractEnumType
             ['name' => 'QUERY', 'value' => self::QUERY],
             ['name' => 'MUTATION', 'value' => self::MUTATION],
             ['name' => 'FIELD', 'value' => self::FIELD],
+            ['name' => 'FIELD_DEFINITION', 'value' => self::FIELD_DEFINITION],
             ['name' => 'FRAGMENT_DEFINITION', 'value' => self::FRAGMENT_DEFINITION],
             ['name' => 'FRAGMENT_SPREAD', 'value' => self::FRAGMENT_SPREAD],
             ['name' => 'INLINE_FRAGMENT', 'value' => self::INLINE_FRAGMENT],
+            ['name' => 'ENUM_VALUE', 'value' => self::ENUM_VALUE],
         ];
     }
 


### PR DESCRIPTION
FIELD_DEFINITION and ENUM_VALUE are valid directive locations, for example with @deprecated. This adds them to the list, and provides some test cases around directives in introspection queries.