### PR TITLE
:bug: Fix PHP8 compatibility

### DIFF
--- a/src/Parser/Ast/ArgumentValue/Variable.php
+++ b/src/Parser/Ast/ArgumentValue/Variable.php
@@ -49,7 +49,7 @@ class Variable extends AbstractAst implements ValueInterface
      * @param bool     $arrayElementNullable
      * @param Location $location
      */
-    public function __construct($name, $type, $nullable, $isArray, $arrayElementNullable = true, Location $location)
+    public function __construct($name, $type, $nullable, $isArray, $arrayElementNullable, Location $location)
     {
         parent::__construct($location);
 


### PR DESCRIPTION
This fix the following bug:

```
Required parameter $location follows optional parameter $arrayElementNullable
```

As the optional parameter was placed before a non-optional one, it is always declared at call sites so we can safely remove the default value.